### PR TITLE
尝试修正少数手机无法选择助战的问题

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -1399,7 +1399,7 @@ function algo_init() {
     function getPTList() {
         let elements = matchAll(/^\+\d*$/);
         let results = [];
-        let left = 0;
+        let left = find(string.support).bounds().left;
         log("PT匹配结果数量" + elements.length);
         for (var element of elements) {
             var content = getContent(element);
@@ -1412,7 +1412,6 @@ function algo_init() {
                             value: Number(getContent(next)),
                             bounds: element.bounds(),
                         });
-                        if (element.bounds().left > left) left = element.bounds().left;
                     }
                 }
             }
@@ -1423,12 +1422,11 @@ function algo_init() {
                         value: Number(content.slice(1)),
                         bounds: element.bounds(),
                     });
-                    if (element.bounds().left > left) left = element.bounds().left;
                 }
             }
         }
 
-        return results.filter((result) => result.bounds.left == left);
+        return results.filter((result) => result.bounds.left >= left);
     }
 
     function getCostAP() {


### PR DESCRIPTION
初步分析，原因应该是：
getPTList是按照控件左边缘来找到Pt控件的，只有满足特征（+号）而且左边缘最靠右的会入选，否则认为可能不是Pt控件（比如，恶搞玩家名）而排除。
但是，某些环境下，屏幕显示范围之外的Pt控件，左边缘横坐标是最靠右的，比正常显示出来的还要靠右，所以就导致显示范围内的Pt控件错误地被排除了。
所以解决方法就是另找一个左边缘横坐标参照，我觉得“请选择支援角色”文本控件就可以，不过还没测试。