### PR TITLE
尝试点击关卡坐标或关卡名称后检测是否出现嗑药窗口，如果出现就切换到助战选择状态

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -1733,9 +1733,13 @@ function algo_init() {
                         log("尝试点击关卡坐标");
                         click(battlepos.x, battlepos.y);
                         waitAny(
-                            [() => find(string.battle_confirm), () => find(string.support)],
+                            [() => find(string.battle_confirm), () => find(string.support), () => find(string.out_of_ap)],
                             5000
                         );
+                        if (find(string.out_of_ap)) {
+                            log("点击关卡坐标后,弹出带\"AP不足\"的AP药选择窗口");
+                            state = STATE_SUPPORT;
+                        }
                     }
                     // click battle if available
                     else if (battlename) {
@@ -1745,9 +1749,13 @@ function algo_init() {
                             let bound = battle.bounds();
                             click(bound.centerX(), bound.centerY());
                             waitAny(
-                                [() => find(string.battle_confirm), () => find(string.support)],
+                                [() => find(string.battle_confirm), () => find(string.support), () => find(string.out_of_ap)],
                                 5000
                             );
+                            if (find(string.out_of_ap)) {
+                                log("点击关卡坐标后,弹出带\"AP不足\"的AP药选择窗口");
+                                state = STATE_SUPPORT;
+                            }
                         }
                     } else {
                         log("等待捕获关卡坐标");


### PR DESCRIPTION
看上去在比较卡顿的机器上，可能是因为助战出现太慢，所以脚本错以为助战还没出现，于是就把助战错当作关卡坐标点击了。
#26 并没有完全修正这个问题，现在再次尝试修正

*之前觉得在state切换到STATE_SUPPORT后，在完成嗑药后还需要等待“请选择支援角色”出现，现在感觉这个应该没必要*