### PR TITLE
Android 7.0以下第一次使用root权限时toast提示用户

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -1188,8 +1188,13 @@ floatUI.adjust = function (key, value) {
 function algo_init() {
 
     var useShizuku = true;
+    var isFirstRootClick = true;
 
     function clickRoot(x, y) {
+        if (isFirstRootClick) {
+            toastLog("Android 7 以下设备运行脚本需要root或Shizuku(adb)权限\n正在尝试Shizuku...");
+            isFirstRootClick = false;
+        }
         //第一次会尝试使用Shizuku，如果失败，则不再尝试Shizuku，直到脚本退出
         if (useShizuku) {
             log("使用Shizuku模拟点击坐标 "+x+","+y);
@@ -1199,7 +1204,7 @@ function algo_init() {
                 result = $shell("input tap "+x+" "+y, false);
             } catch (e) {
                 useShizuku = false;
-                toastLog("Shizuku未安装/未启动,或者未授权");
+                toastLog("Shizuku未安装/未启动,或者未授权\n尝试直接使用root权限...");
                 log(e);
             }
 


### PR DESCRIPTION
加这个toast主要是今天有人误解了“Shizuku未授权”这个toast的意思（他以为问题出在一个叫“Shizuku”的不知道是啥的东西身上，但实际情况应该是模拟器没开root权限，然后su执行命令蛋疼阻塞了，而且没有弹出root授权申请窗口）

-----

其实我还有一些想法：

1. Shizuku目前是没有toast通知提示的，所以不会干扰截屏，这一点也许需要告知用户

2. 可以浏览器弹出对应的下载链接，尤其是Android 5环境需要用旧版Shizuku

但目前先不管这么多……