### PR TITLE
（全部合并）重写坐标转换并支持防断线模式

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -1783,7 +1783,7 @@ function algo_init() {
     function initialize() {
         if (auto.root == null) {
             toastLog("未开启无障碍服务");
-            //到这里还不会弹出申请开启无障碍服务的弹窗；后面执行到packageName()这个UI选择器时就会弹窗申请开启无障碍服务
+            selector().depth(0).findOnce();//弹出申请开启无障碍服务的弹窗
         }
 
         //检测区服

--- a/floatUI.js
+++ b/floatUI.js
@@ -1391,6 +1391,26 @@ function algo_init() {
         } while (wait === true || (wait && new Date().getTime() < startTime + wait));
     }
 
+    function findPackageName(name, wait) {
+        var startTime = new Date().getTime();
+        var result = null;
+        var it = 0;
+        do {
+            it++;
+            try {
+                auto.root.refresh();
+            } catch (e) {
+                log(e);
+                sleep(100);
+                continue;
+            }
+            result = packageName(name).findOnce();
+            if (result && result.refresh()) break;
+            sleep(100);
+        } while (wait === true || (wait && new Date().getTime() < startTime + wait));
+        return result;
+    }
+
     function waitAny(fnlist, wait) {
         var startTime = new Date().getTime();
         var result = null;
@@ -1633,7 +1653,8 @@ function algo_init() {
         }
         let lang = null;
         for (lang in strings) {
-            if (packageName(strings[lang][strings.name.findIndex((e) => e == "package_name")]).findOnce()) {
+            if (lang == "name") continue;
+            if (findPackageName(strings[lang][strings.name.findIndex((e) => e == "package_name")], 1000)) {
                 log("区服", lang);
                 break;
             }

--- a/floatUI.js
+++ b/floatUI.js
@@ -1987,7 +1987,7 @@ function algo_init() {
         newpoint.x *= scalerate;
         newpoint.y *= scalerate;
 
-        //刘海屏
+        //移动坐标，使画面横向位置位于屏幕中央，以及加上刘海屏的额外偏移
         newpoint.x += gameoffset.x;
         newpoint.y += gameoffset.y;
 

--- a/floatUI.js
+++ b/floatUI.js
@@ -1641,35 +1641,33 @@ function algo_init() {
     };
 
     var string = {};
+    var lang = null;
+
+    function detectGameLang() {
+        let detectedLang = null;
+        for (detectedLang in strings) {
+            if (detectedLang == "name") continue;
+            if (findPackageName(strings[detectedLang][strings.name.findIndex((e) => e == "package_name")], 1000)) {
+                log("区服", detectedLang);
+                break;
+            }
+            detectedLang = null;
+        }
+        if (detectedLang != null) {
+            lang = detectedLang;
+            for (let i = 0; i < strings.name.length; i++) {
+                string[strings.name[i]] = strings[lang][i];
+            }
+            return detectedLang;
+        }
+        return null;
+    }
 
     var screen = {width: 0, height: 0, type: "normal"};
     var gamebounds = null;
     var gameoffset = {x: 0, y: 0, center: {y: 0}, bottom: {y: 0}};
 
-    function initialize() {
-        if (auto.root == null) {
-            toastLog("未开启无障碍服务");
-            //到这里还不会弹出申请开启无障碍服务的弹窗；后面执行到packageName()这个UI选择器时就会弹窗申请开启无障碍服务
-        }
-        let lang = null;
-        for (lang in strings) {
-            if (lang == "name") continue;
-            if (findPackageName(strings[lang][strings.name.findIndex((e) => e == "package_name")], 1000)) {
-                log("区服", lang);
-                break;
-            }
-            lang = null;
-        }
-        if (lang != null) {
-            for (let i = 0; i < strings.name.length; i++) {
-                string[strings.name[i]] = strings[lang][i];
-            }
-        } else {
-            toastLog("未在前台检测到魔法纪录,退出");
-            threads.currentThread().interrupt();
-        }
-
-        //检测屏幕参数
+    function detectScreenParams() {
         //开始脚本前可能转过屏之类的，所以参数需要先重置
         screen = {width: 0, height: 0, type: "normal"};
         gamebounds = null;
@@ -1757,6 +1755,22 @@ function algo_init() {
             gameoffset.y += parseInt(gamebounds.centerY() - (screen.height / 2));
         }
         log("gameoffset", gameoffset);
+    }
+
+    function initialize() {
+        if (auto.root == null) {
+            toastLog("未开启无障碍服务");
+            //到这里还不会弹出申请开启无障碍服务的弹窗；后面执行到packageName()这个UI选择器时就会弹窗申请开启无障碍服务
+        }
+
+        //检测区服
+        if (detectGameLang() == null) {
+            toastLog("未在前台检测到魔法纪录,退出");
+            threads.currentThread().interrupt();
+        }
+
+        //检测屏幕参数
+        detectScreenParams();
     }
 
     //绿药或红药，每次消耗1个

--- a/main.js
+++ b/main.js
@@ -65,6 +65,7 @@ ui.layout(
                                 <text text="注意:回复药开关状态和个数限制不会永久保存,在脚本完全退出后,这些设置会被重置!" textColor="#666666" />
                             </vertical>
                             <Switch id="justNPC" w="*" margin="0 5" checked="false" textColor="#000000" text="只使用NPC(不选则先互关好友,后NPC)" />
+                            <Switch id="autoReconnect" w="*" margin="0 3" checked="false" textColor="#000000" text="防断线模式(尽可能自动点击断线重连按钮)" />
                         </vertical>
                     </vertical>
                     <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
@@ -87,7 +88,6 @@ ui.layout(
                     <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
                         <text text="备用脚本设置" textColor="#000000" padding="5" w="*" bg="#eeeeee" />
                         <vertical padding="10 6 0 6" w="*" h="auto">
-                            <Switch id="isStable" w="*" margin="0 3" checked="false" textColor="#000000" text="稳定模式（战斗中不断点击重连弹窗位置）" />
                             <text text="活动周回关卡选择:" textColor="#000000" margin="0 5" />
                             <radiogroup id="battleNo" padding="10 3 0 3">
                                 <radio id="cb1" text="初级" />
@@ -338,7 +338,7 @@ if (!floaty.checkPermission()) {
 }
 
 var storage = storages.create("auto_mr");
-const persistParamList = ["foreground", "default", "isStable", "justNPC", "helpx", "helpy", "battleNo", "useAuto", "timeout"]
+const persistParamList = ["foreground", "default", "autoReconnect", "justNPC", "helpx", "helpy", "battleNo", "useAuto", "timeout"]
 const tempParamList = ["drug1", "drug2", "drug3", "drug4", "drug1num", "drug2num", "drug3num", "drug4num", "apmul"]
 
 var idmap = {};


### PR DESCRIPTION
合并 #39 #41 #42 #43 #45 #46 #47 #49 #50

增加重写的坐标转换（包括根据转屏方向修正刘海屏参数）；
稳定模式改名为防断线模式并支持新版周回脚本；
点击再战按钮时使用已知坐标进行换算（否则分辨率小于16:9的屏幕会点不到再战按钮）；
重写区服检测

*防断线模式目前局限性很大，目前发现只有战斗开始或结束（正要开始结算）的时候才能直接重连，否则只会被强制重新登录回首页*

*原先这些改动放在 #39 ，重新整理后改为放在这里*