### PR TITLE
让isDrugEnough在日志中更清晰地打出回复药状态；如果limit.drugX未启用则返回false

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -1626,8 +1626,15 @@ function algo_init() {
         //从游戏界面上读取剩余回复药个数后，作为count传入进来
         let remainingnum = parseInt(count);
         let limitnum = parseInt(limit["drug"+(index+1)+"num"]);
-        log("第"+(index+1)+"种回复药还剩"+remainingnum+"个");
-        log("根据嗑药个数限制,还可以继续磕"+limitnum+"个");
+        log(
+        "\n第"+(index+1)+"种回复药"
+        +"\n"+(limit["drug"+(index+1)]?"已启用":"已禁用")
+        +"\n剩余:    "+remainingnum+"个"
+        +"\n个数限制:"+limitnum+"个"
+        );
+
+        //如果未启用则直接返回false
+        if (!limit["drug"+(index+1)]) return false;
 
         //如果传入了undefined、""等等，parseInt将会返回NaN，然后NaN与数字比大小的结果将会是是false
         if (limitnum < drugCosts[index]) return false;


### PR DESCRIPTION
在这个改动之前，其实是忽略了limit.drug1/2/3，只看limit.drug1/2/3num是否为0来顺带检查嗑药设置是否启用。因为嗑药数量不会永久保存，而且点击嗑药复选框时已经会正确设置limit.drug1/2/3/4num，所以之前也可以正常工作。

保险起见，还是在isDrugEnough这里检查一下limit.drug1/2/3。