### PR TITLE
修正：让getAP函数接受等待时间参数

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -1472,8 +1472,7 @@ function algo_init() {
 
     //检测AP，缺省wait的情况下只检测一次就退出
     function getAP(wait) {
-        var startTime = 0;
-        if (wait != null) startTime = new Date().getTime();
+        var startTime = new Date().getTime();
 
         if (findID("baseContainer")) {
             // values and seperator are together
@@ -1501,7 +1500,7 @@ function algo_init() {
                 }
                 if (result) return result;
                 sleep(100);
-            } while (wait != null && new Date().getTime() < startTime + wait);
+            } while (wait === true || (wait && new Date().getTime() < startTime + wait));
         } else {
             // ... are seperate
             do {
@@ -1532,7 +1531,7 @@ function algo_init() {
                 }
                 if (result) return result;
                 sleep(100);
-            } while (wait != null && new Date().getTime() < startTime + wait);
+            } while (wait === true || (wait && new Date().getTime() < startTime + wait));
         }
     }
 

--- a/floatUI.js
+++ b/floatUI.js
@@ -1480,7 +1480,7 @@ function algo_init() {
             do {
                 let result = null;
                 let h = getWindowSize().y;
-                let elements = matchAll(/^\d+\/\d+$/, true);
+                let elements = matchAll(/^\d+\/\d+$/, false);
                 for (let element of elements) {
                     if (element.bounds().top < h) {
                         if (
@@ -1507,7 +1507,7 @@ function algo_init() {
             do {
                 let result = null;
                 let h = getWindowSize().y;
-                let elements = findAll("/", true);
+                let elements = findAll("/", false);
                 for (let element of elements) {
                     if (element.bounds().top < h) {
                         if (


### PR DESCRIPTION
这其实是 #47 忘了改的地方（捂脸）……

1. 在getAP中调用matchAll和findAll时，wait都设为false，否则仍然可能会无限制地等下去
2. 照搬waitAny等函数的写法

--------

在 #47 之前getAP是阻塞的，而且只有refillAP()里的一个地方有调用。

改这个是为了给以后自动重启游戏、自动登录做准备，用来检测是不是已经成功登录，我觉得能检测AP的话就说明已经登录进游戏了（虽然未必是在主页）。即便之前还有未完成战斗，也可以点击继续战斗按钮，然后战斗还是迟早结束（如果自动战斗启用的话）。

因为检测不到AP的时候（应该是还没点击屏幕到成功登录进主页）还需要点击屏幕，所以不能让他永远阻塞，需要设一个超时。