### PR TITLE
避免getDisplayCutout()返回null时崩溃

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -1741,7 +1741,7 @@ function algo_init() {
         if (device.sdkInt >= 28) {
             //Android 9或以上有原生的刘海屏API
             //处理转屏
-            if (limit.cutoutParams != null) {
+            if (limit.cutoutParams != null && limit.cutoutParams.cutout != null) {
                 let initialRotation = limit.cutoutParams.rotation;
                 let display = context.getSystemService(android.content.Context.WINDOW_SERVICE).getDefaultDisplay();
                 let currentRotation = display.getRotation();


### PR DESCRIPTION
Android 9或以上，但屏幕没有刘海的情况下getDisplayCutout()就会返回null