### PR TITLE
【活动内存爆炸临时方案】自动重开刷活动门票脚本

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -539,6 +539,7 @@ var limit = {
     jjcnum: '',
     default: 0,
     useAuto: true,
+    refillMax: true,
 }
 var clickSets = {
     ap: {
@@ -1612,7 +1613,7 @@ function algo_init() {
             var element = find(string.revive_title, true);
             var apinfo = getAP();
             log("当前AP:" + apinfo.value + "/" + apinfo.total);
-        } while (usedrug && limit.useAuto && apinfo.value <= apinfo.total * AUTO_LIMIT);
+        } while (usedrug && (limit.useAuto && limit.refillMax) && apinfo.value <= apinfo.total * AUTO_LIMIT);
         // now close the window
         while (element.refresh()) {
             log("关闭回复窗口");
@@ -1711,7 +1712,7 @@ function algo_init() {
                         apinfo.total
                     );
                     if (
-                        ((limit.useAuto && apinfo.value <= apinfo.total * AUTO_LIMIT) ||
+                        (((limit.useAuto && limit.refillMax) && apinfo.value <= apinfo.total * AUTO_LIMIT) ||
                             (apcost && apinfo.value < apcost * 2)) &&
                         usedrug &&
                         tryusedrug

--- a/floatUI.js
+++ b/floatUI.js
@@ -2050,6 +2050,7 @@ function algo_init() {
         if(match(string.regex_until)) state = STATE_HOME;
         else if(find(string.support)) state = STATE_SUPPORT;
         else if(findID("nextPageBtn")) state = STATE_TEAM;
+        else if(find("BATTLE 1")) state=STATE_MENU;
         while (true) {
             switch (state) {
                 case STATE_LOGIN:{
@@ -2065,7 +2066,7 @@ function algo_init() {
                     break;
                 }
                 case STATE_HOME:{
-                    if(match(/^BATTLE.+/)){
+                    if(find("BATTLE 1")){
                         state=STATE_MENU;
                         log("进入关卡选择");
                         break;
@@ -2162,7 +2163,7 @@ function algo_init() {
                         last=Date.now();
                         state=STATE_LOGIN;
                         log("重启游戏进程，进入登录页面");
-                    } else if((Date.now()>last+1000*60*60) && findID("charaWrap")){
+                    } else if(((Date.now()>last+1000*60*60) && findID("charaWrap"))||(Date.now()>last+1000*60*65)){
                         log("尝试关闭游戏进程");
                         backtoMain();
                         sleep(5000)

--- a/floatUI.js
+++ b/floatUI.js
@@ -2076,7 +2076,7 @@ function algo_init() {
                         if (element && element.refresh()) {
                             log("尝试关闭弹窗");
                             let bound = element.bounds();
-                            click(bound.right, bound.top);
+                            click(bound.right-8, bound.top+8);
                         }
                     }
                     let element=match(string.regex_until)
@@ -2169,8 +2169,10 @@ function algo_init() {
                         sleep(5000)
                         killBackground(pkgName);
                         sleep(10000)
-                    } else if (limit.autoReconnect) {
+                    } else if (limit.autoReconnect && !findID("charaWrap")) {
                         clickReconnect();
+                        //slow down
+                        findID("charaWrap",2000);
                     }
                     break;
                 }

--- a/floatUI.js
+++ b/floatUI.js
@@ -56,7 +56,7 @@ floatUI.scripts = [
         fn: autoMainver1,
     },
     {
-        name: "每40分钟自动重开，刷活动剧情1",
+        name: "每小时自动重开，刷剧情1",
         fn: tasks.reopen,
     },
 ];
@@ -1631,7 +1631,7 @@ function algo_init() {
             /^最终登录.+/,
             /＋\d+个$/,
             /[\s\S]*续战/,
-            /截止$/,
+            /.+截止$/,
             "com.bilibili.madoka.bilibili",
         ],
         zh_Hant: [
@@ -1650,7 +1650,7 @@ function algo_init() {
             /^最終登入.+/,
             /＋\d+個$/,
             /[\s\S]*周回/,
-            /為止$/,
+            /.+為止$/,
             "com.komoe.madokagp",
         ],
         ja: [
@@ -1669,7 +1669,7 @@ function algo_init() {
             /^最終ログイン.+/,
             /＋\d+個$/,
             /[\s\S]*周回/,
-            /まで$/,
+            /.+まで$/,
             "com.aniplex.magireco",
         ],
     };
@@ -2070,6 +2070,14 @@ function algo_init() {
                         log("进入关卡选择");
                         break;
                     }
+                    if (findID("popupInfoDetailTitle")) {
+                        let element = className("EditText").findOnce();
+                        if (element && element.refresh()) {
+                            log("尝试关闭弹窗");
+                            let bound = element.bounds();
+                            click(bound.right, bound.top);
+                        }
+                    }
                     let element=match(string.regex_until)
                     if(element){
                         click(element.bounds().centerX(),element.bounds().centerY())
@@ -2154,12 +2162,14 @@ function algo_init() {
                         last=Date.now();
                         state=STATE_LOGIN;
                         log("重启游戏进程，进入登录页面");
-                    } else if((Date.now()>last+1000*60*40) && findID("charaWrap")){
+                    } else if((Date.now()>last+1000*60*60) && findID("charaWrap")){
                         log("尝试关闭游戏进程");
                         backtoMain();
                         sleep(5000)
                         killBackground(pkgName);
                         sleep(10000)
+                    } else if (limit.autoReconnect) {
+                        clickReconnect();
                     }
                     break;
                 }

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 "ui";
+importClass(android.view.View)
 importClass(android.graphics.Color)
 importClass(android.view.MenuItem)
 importClass(com.stardust.autojs.project.ProjectConfig)
@@ -64,7 +65,8 @@ ui.layout(
                     <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
                         <text text="脚本设置" textColor="#000000" padding="5" w="*" bg="#eeeeee"/>
                         <vertical padding="10 6 0 6" w="*" h="auto">
-                            <Switch id="useAuto" w="*" margin="0 3" checked="true" textColor="#666666" text="优先使用官方auto（如设置用药则回复到4倍上限）" />
+                            <Switch id="useAuto" w="*" margin="0 3" checked="true" textColor="#666666" text="优先使用官方auto" />
+                            <Switch id="refillMax" w="*" margin="0 3" checked="true" textColor="#666666" visibility="visible" text="嗑药到4倍上限（不开则每次嗑一瓶）" />
                         </vertical>
                     </vertical>
                     <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
@@ -150,10 +152,14 @@ ui.autoService.setOnCheckedChangeListener(function (widget, checked) {
     ui.autoService.setChecked(auto.service != null)
 });
 //前台服务
+ui.foreground.setChecked($settings.isEnabled('foreground_service'));
 ui.foreground.setOnCheckedChangeListener(function (widget, checked) {
     $settings.setEnabled('foreground_service', checked);
 });
-ui.foreground.setChecked($settings.isEnabled('foreground_service'));
+
+ui.useAuto.setOnCheckedChangeListener(function (widget, checked) {
+    ui.refillMax.setVisibility(checked ? View.VISIBLE : View.GONE);
+});
 
 //回到本界面时，resume事件会被触发
 ui.emitter.on("resume", () => {
@@ -189,7 +195,7 @@ if (!floaty.checkPermission()) {
 }
 
 var storage = storages.create("auto_mr");
-const persistParamList = ["foreground", "default", "isStable", "justNPC", "helpx", "helpy", "battleNo", "useAuto"]
+const persistParamList = ["foreground", "default", "isStable", "justNPC", "helpx", "helpy", "battleNo", "useAuto", "refillMax"]
 const tempParamList = ["drug1", "drug2", "drug3", "jjcisuse", "drug1num", "drug2num", "drug3num", "jjcnum"]
 
 var idmap={};


### PR DESCRIPTION
自己用了几天，效果还不错。反正也没几天了，没考虑各种兼容性，放上来先用着吧。独立脚本也不会影响其它的代码。
原理很简单，每隔一段时间杀掉一次游戏，等十几秒让系统自动回收内存，然后再重开进入剧情1自动续战。
在选人选关战斗首页开都可以，就是开了之后不能有其它操作。