### PR TITLE
app启动时就检测root或adb权限；增加privShell等函数，如果仍然没权限就再次申请

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -639,54 +639,66 @@ floatUI.main = function () {
     requestShellPrivilege = function () {
         if (limit.privilege) {
             log("已经获取到root或adb权限了");
-        } else {
-            let shellcmd = "cat /proc/self/status";
-            let result = null;
-            try {
-                result = shizukuShell(shellcmd);
-            } catch (e) {
-                result = {code: 1, result: "-1", err: ""};
-                log(e);
-            }
-            let euid = -1;
-            if (result.code == 0) {
-                euid = getEUID(result.result);
-                switch (euid) {
-                case 0:
-                    log("Shizuku有root权限");
-                    limit.privilege = {shizuku: {uid: euid}};
-                    break;
-                case 2000:
-                    log("Shizuku有adb shell权限");
-                    limit.privilege = {shizuku: {uid: euid}};
-                    break;
-                default:
-                    log("通过Shizuku获取权限失败，Shizuku是否正确安装并启动了？");
-                    limit.privilege = null;
-                }
-            } else {
-                toastLog("Shizuku没有安装/没有启动/没有授权\n尝试直接获取root权限...");
-                sleep(2500);
-                toastLog("请务必选择“永久”授权，而不是一次性授权！");
-                result = rootShell(shellcmd);
-                if (result.code == 0) euid = getEUID(result.result);
-                if (euid == 0) {
-                    log("直接获取root权限成功");
-                    limit.privilege = {shizuku: null};
-                } else {
-                    log("直接获取root权限失败");
-                    limit.privilege = null;
-                    if (device.sdkInt >= 23) {
-                        toastLog("请下载安装Shizuku,并按照说明启动它\n然后在Shizuku中给本应用授权");
-                        $app.openUrl("https://shizuku.rikka.app/zh-hans/download.html");
-                    } else {
-                        toastLog("Android版本低于6，Shizuku不能使用最新版\n请安装并启动Shizuku 3.6.1，并给本应用授权");
-                        $app.openUrl("https://github.com/RikkaApps/Shizuku/releases/tag/v3.6.1");
-                    }
-                    sleep(1000);
-                }
+            return limit.privilege;
+        }
+
+        let rootMarkerPath = files.join(engines.myEngine().cwd(), "hasRoot");
+
+        let shellcmd = "cat /proc/self/status";
+        let result = null;
+        try {
+            result = shizukuShell(shellcmd);
+        } catch (e) {
+            result = {code: 1, result: "-1", err: ""};
+            log(e);
+        }
+        let euid = -1;
+        if (result.code == 0) {
+            euid = getEUID(result.result);
+            switch (euid) {
+            case 0:
+                log("Shizuku有root权限");
+                limit.privilege = {shizuku: {uid: euid}};
+                break;
+            case 2000:
+                log("Shizuku有adb shell权限");
+                limit.privilege = {shizuku: {uid: euid}};
+                break;
+            default:
+                log("通过Shizuku获取权限失败，Shizuku是否正确安装并启动了？");
+                limit.privilege = null;
             }
         }
+
+        if (limit.privilege != null) return;
+
+        if (!files.isFile(rootMarkerPath)) {
+            toastLog("Shizuku没有安装/没有启动/没有授权\n尝试直接获取root权限...");
+            sleep(2500);
+            toastLog("请务必选择“永久”授权，而不是一次性授权！");
+        } else {
+            log("Shizuku没有安装/没有启动/没有授权\n之前成功直接获取过root权限,再次检测...");
+        }
+        result = rootShell(shellcmd);
+        if (result.code == 0) euid = getEUID(result.result);
+        if (euid == 0) {
+            log("直接获取root权限成功");
+            limit.privilege = {shizuku: null};
+            files.create(rootMarkerPath);
+        } else {
+            toastLog("直接获取root权限失败！");
+            sleep(2500);
+            limit.privilege = null;
+            files.remove(rootMarkerPath);
+            if (device.sdkInt >= 23) {
+                toastLog("请下载安装Shizuku,并按照说明启动它\n然后在Shizuku中给本应用授权");
+                $app.openUrl("https://shizuku.rikka.app/zh-hans/download.html");
+            } else {
+                toastLog("Android版本低于6，Shizuku不能使用最新版\n请安装并启动Shizuku 3.6.1，并给本应用授权");
+                $app.openUrl("https://github.com/RikkaApps/Shizuku/releases/tag/v3.6.1");
+            }
+        }
+
         return limit.privilege;
     }
 

--- a/floatUI.js
+++ b/floatUI.js
@@ -37,6 +37,15 @@ var tasks = algo_init();
 var capture = () => { };
 // 停止脚本线程，尤其是防止停止自己的时候仍然继续往下执行少许语句（同上，会在main函数中初始化）
 var stopThread = () => { };
+// （不）使用Shizuku/root执行shell命令
+var shizukuShell = () => { };
+var rootShell = () => { };
+var privShell = () => { };
+var normalShell = () => { };
+// 检查root或adb权限
+var getEUID = () => { };
+var requestShellPrivilege = () => { };
+var requestShellPrivilegeThread = null;
 // available script list
 floatUI.scripts = [
     {
@@ -568,6 +577,111 @@ floatUI.main = function () {
     //脚本启动时检测一次
     adjustCutoutParams();
 
+    //使用Shizuku执行shell命令
+    shizukuShell = function (shellcmd) {
+        $shell.setDefaultOptions({adb: true});
+        let result = $shell(shellcmd);
+        $shell.setDefaultOptions({adb: false});
+        return result;
+    };
+    //直接使用root权限执行shell命令
+    rootShell = function (shellcmd) {
+        $shell.setDefaultOptions({adb: false});
+        return $shell(shellcmd, true);
+    };
+    //根据情况使用Shizuku还是直接使用root执行shell命令
+    privShell = function (shellcmd) {
+        if (limit.privilege) {
+            if (limit.privilege.shizuku) {
+                return shizukuShell(shellcmd);
+            } else {
+                return rootShell(shellcmd);
+            }
+        } else {
+            if (requestShellPrivilegeThread != null && requestShellPrivilegeThread.isAlive()) {
+                toastLog("已经在尝试申请root或adb权限了\n请稍后重试,或彻底退出脚本后重试");
+            } else {
+                requestShellPrivilegeThread = threads.start(requestShellPrivilege);
+            }
+            throw new Error("没有root或adb权限");
+        }
+    }
+    //不使用特权执行shell命令
+    normalShell = function (shellcmd) {
+        $shell.setDefaultOptions({adb: false});
+        return $shell(shellcmd);
+    }
+
+    //检查并申请root或adb权限
+    getEUID = function (procStatusContent) {
+        let matched = procStatusContent.match(/(^|\n)Uid:\s+\d+\s+\d+\s+\d+\s+\d+($|\n)/);
+        if (matched != null) {
+            matched = matched[0].match(/\d+(?=\s+\d+\s+\d+($|\n))/);
+        }
+        if (matched != null) {
+            return parseInt(matched[0]);
+        } else {
+            return -1;
+        }
+    }
+    requestShellPrivilege = function () {
+        if (limit.privilege) {
+            log("已经获取到root或adb权限了");
+        } else {
+            let shellcmd = "cat /proc/self/status";
+            let result = null;
+            try {
+                result = shizukuShell(shellcmd);
+            } catch (e) {
+                result = {code: 1, result: "-1", err: ""};
+                log(e);
+            }
+            let euid = -1;
+            if (result.code == 0) {
+                euid = getEUID(result.result);
+                switch (euid) {
+                case 0:
+                    log("Shizuku有root权限");
+                    limit.privilege = {shizuku: {uid: euid}};
+                    break;
+                case 2000:
+                    log("Shizuku有adb shell权限");
+                    limit.privilege = {shizuku: {uid: euid}};
+                    break;
+                default:
+                    log("通过Shizuku获取权限失败，Shizuku是否正确安装并启动了？");
+                    limit.privilege = null;
+                }
+            } else {
+                toastLog("Shizuku没有安装/没有启动/没有授权\n尝试直接获取root权限...");
+                sleep(2500);
+                toastLog("请务必选择“永久”授权，而不是一次性授权！");
+                result = rootShell(shellcmd);
+                if (result.code == 0) euid = getEUID(result.result);
+                if (euid == 0) {
+                    log("直接获取root权限成功");
+                    limit.privilege = {shizuku: null};
+                } else {
+                    log("直接获取root权限失败");
+                    limit.privilege = null;
+                    if (device.sdkInt >= 23) {
+                        toastLog("请下载安装Shizuku,并按照说明启动它\n然后在Shizuku中给本应用授权");
+                        $app.openUrl("https://shizuku.rikka.app/zh-hans/download.html");
+                    } else {
+                        toastLog("Android版本低于6，Shizuku不能使用最新版\n请安装并启动Shizuku 3.6.1，并给本应用授权");
+                        $app.openUrl("https://github.com/RikkaApps/Shizuku/releases/tag/v3.6.1");
+                    }
+                    sleep(1000);
+                }
+            }
+        }
+        return limit.privilege;
+    }
+
+    if (requestShellPrivilegeThread == null || !requestShellPrivilegeThread.isAlive()) {
+        requestShellPrivilegeThread = threads.start(requestShellPrivilege);
+    }
+
 };
 // ------------主要逻辑--------------------
 var langNow = "zh"
@@ -594,7 +708,9 @@ var limit = {
     default: 0,
     useAuto: true,
     apmul: "",
-    timeout: "5000"
+    timeout: "5000",
+    useScreencap: false,
+    privilege: null,
 }
 var clickSets = {
     ap: {
@@ -1226,51 +1342,9 @@ floatUI.logParams = function () {
 // compatible action closure
 function algo_init() {
 
-    var useShizuku = true;
-    var isFirstRootClick = true;
-
     function clickRoot(x, y) {
-        if (isFirstRootClick) {
-            toastLog("Android 7 以下设备运行脚本需要root或Shizuku(adb)权限\n正在尝试Shizuku...");
-            isFirstRootClick = false;
-        }
-        //第一次会尝试使用Shizuku，如果失败，则不再尝试Shizuku，直到脚本退出
-        if (useShizuku) {
-            log("使用Shizuku模拟点击坐标 "+x+","+y);
-            $shell.setDefaultOptions({adb: true});
-            var result = null;
-            try {
-                result = $shell("input tap "+x+" "+y, false);
-            } catch (e) {
-                useShizuku = false;
-                toastLog("Shizuku未安装/未启动,或者未授权\n尝试直接使用root权限...");
-                log(e);
-            }
-
-            //这里useShizuku实际上指示了是否捕获到抛出的异常
-            if (!useShizuku || result == null || result.code != 0) {
-                useShizuku = false;
-                log("使用Shizuku执行模拟点击命令失败,尝试直接使用root权限");
-            } else {
-                log("模拟点击完成");
-                return;//命令成功执行
-            }
-        }
-
-        //第一次尝试Shizuku失败后也会走到这里
-        if (!useShizuku) {
-            log("直接使用root权限模拟点击坐标 "+x+","+y);
-            $shell.setDefaultOptions({adb: false});
-            //直接设置第二个参数root为true在某些模拟器上可能无法弹出授权窗口,或者即便弹出了也无法点允许
-            //result = $shell("input tap "+x+" "+y, true);
-            result = $shell("su\ninput tap "+x+" "+y+"\nexit\n");
-            if (result == null || result.code != 0) {
-                toastLog("Android 7 以下设备运行脚本需要root\n没有root权限,退出");
-                stopThread();
-            } else {
-                log("模拟点击完成");
-            }
-        }
+        let shellcmd = "input tap "+x+" "+y;
+        privShell(shellcmd);//没权限就会抛异常
     }
 
     function click(x, y) {

--- a/floatUI.js
+++ b/floatUI.js
@@ -643,7 +643,7 @@ floatUI.main = function () {
             let shellcmd = "cat /proc/self/status";
             let result = null;
             try {
-                result = shizukuShell(shellcmd, logstring);
+                result = shizukuShell(shellcmd);
             } catch (e) {
                 result = {code: 1, result: "-1", err: ""};
                 log(e);
@@ -668,7 +668,7 @@ floatUI.main = function () {
                 toastLog("Shizuku没有安装/没有启动/没有授权\n尝试直接获取root权限...");
                 sleep(2500);
                 toastLog("请务必选择“永久”授权，而不是一次性授权！");
-                result = rootShell(shellcmd, logstring);
+                result = rootShell(shellcmd);
                 if (result.code == 0) euid = getEUID(result.result);
                 if (euid == 0) {
                     log("直接获取root权限成功");

--- a/floatUI.js
+++ b/floatUI.js
@@ -678,8 +678,10 @@ floatUI.main = function () {
         return limit.privilege;
     }
 
-    if (requestShellPrivilegeThread == null || !requestShellPrivilegeThread.isAlive()) {
-        requestShellPrivilegeThread = threads.start(requestShellPrivilege);
+    if (limit.useScreencap || device.sdkInt < 24) {
+        if (requestShellPrivilegeThread == null || !requestShellPrivilegeThread.isAlive()) {
+            requestShellPrivilegeThread = threads.start(requestShellPrivilege);
+        }
     }
 
 };

--- a/floatUI.js
+++ b/floatUI.js
@@ -1261,7 +1261,9 @@ function algo_init() {
         if (!useShizuku) {
             log("直接使用root权限模拟点击坐标 "+x+","+y);
             $shell.setDefaultOptions({adb: false});
-            result = $shell("input tap "+x+" "+y, true);//第二个参数true表示使用root权限
+            //直接设置第二个参数root为true在某些模拟器上可能无法弹出授权窗口,或者即便弹出了也无法点允许
+            //result = $shell("input tap "+x+" "+y, true);
+            result = $shell("su\ninput tap "+x+" "+y+"\nexit\n");
             if (result == null || result.code != 0) {
                 toastLog("Android 7 以下设备运行脚本需要root\n没有root权限,退出");
                 stopThread();

--- a/floatUI.js
+++ b/floatUI.js
@@ -578,24 +578,32 @@ floatUI.main = function () {
     adjustCutoutParams();
 
     //使用Shizuku执行shell命令
-    shizukuShell = function (shellcmd) {
+    shizukuShell = function (shellcmd, logstring) {
+        if (logstring === true || (logstring !== false && logstring == null))
+            logstring = "使用Shizuku执行shell命令: ["+shellcmd+"]";
+        if (logstring !== false) log("使用Shizuku"+logstring);
         $shell.setDefaultOptions({adb: true});
         let result = $shell(shellcmd);
         $shell.setDefaultOptions({adb: false});
+        if (logstring !== false) log("使用Shizuku"+logstring+" 完成");
         return result;
     };
     //直接使用root权限执行shell命令
-    rootShell = function (shellcmd) {
+    rootShell = function (shellcmd, logstring) {
+        if (logstring === true || (logstring !== false && logstring == null))
+            logstring = "直接使用root权限执行shell命令: ["+shellcmd+"]";
+        if (logstring !== false) log("直接使用root权限"+logstring);
         $shell.setDefaultOptions({adb: false});
+        if (logstring !== false) log("直接使用root权限"+logstring+" 完成");
         return $shell(shellcmd, true);
     };
     //根据情况使用Shizuku还是直接使用root执行shell命令
-    privShell = function (shellcmd) {
+    privShell = function (shellcmd, logstring) {
         if (limit.privilege) {
             if (limit.privilege.shizuku) {
-                return shizukuShell(shellcmd);
+                return shizukuShell(shellcmd, logstring);
             } else {
-                return rootShell(shellcmd);
+                return rootShell(shellcmd, logstring);
             }
         } else {
             if (requestShellPrivilegeThread != null && requestShellPrivilegeThread.isAlive()) {
@@ -607,8 +615,12 @@ floatUI.main = function () {
         }
     }
     //不使用特权执行shell命令
-    normalShell = function (shellcmd) {
+    normalShell = function (shellcmd, logstring) {
+        if (logstring === true || (logstring !== false && logstring == null))
+            logstring = "不使用特权执行shell命令: ["+shellcmd+"]";
+        if (logstring !== false) log("不使用特权"+logstring);
         $shell.setDefaultOptions({adb: false});
+        if (logstring !== false) log("不使用特权"+logstring+" 完成");
         return $shell(shellcmd);
     }
 
@@ -631,7 +643,7 @@ floatUI.main = function () {
             let shellcmd = "cat /proc/self/status";
             let result = null;
             try {
-                result = shizukuShell(shellcmd);
+                result = shizukuShell(shellcmd, logstring);
             } catch (e) {
                 result = {code: 1, result: "-1", err: ""};
                 log(e);
@@ -656,7 +668,7 @@ floatUI.main = function () {
                 toastLog("Shizuku没有安装/没有启动/没有授权\n尝试直接获取root权限...");
                 sleep(2500);
                 toastLog("请务必选择“永久”授权，而不是一次性授权！");
-                result = rootShell(shellcmd);
+                result = rootShell(shellcmd, logstring);
                 if (result.code == 0) euid = getEUID(result.result);
                 if (euid == 0) {
                     log("直接获取root权限成功");
@@ -1346,7 +1358,7 @@ function algo_init() {
 
     function clickRoot(x, y) {
         let shellcmd = "input tap "+x+" "+y;
-        privShell(shellcmd);//没权限就会抛异常
+        privShell(shellcmd, "模拟点击坐标 ["+x+","+y+"]");//没权限就会抛异常
     }
 
     function click(x, y) {


### PR DESCRIPTION
直接设置第二个参数root为true在某些模拟器上可能无法弹出授权窗口,或者即便弹出了也无法点允许

*很奇怪，同样是直接设置第二个参数root为true，改成app启动时就申请root，在MuMu上貌似反倒又没问题了*