### PR TITLE
拒绝在无障碍服务抓取模式为压缩（也就是“稳定模式”）下运行脚本

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -2435,10 +2435,11 @@ function algo_init() {
         }
         log("detected_screen", detected_screen, "detected_gameoffset", detected_gameoffset);
 
-        detected_gamebounds = getFragmentViewBounds(string.package_name);
+        let element = selector().packageName(string.package_name).className("android.widget.EditText").algorithm("BFS").findOnce();
+        log("EditText bounds", element.bounds());
+        element = element.parent();
+        detected_gamebounds = element.bounds();
         log("detected_gamebounds", detected_gamebounds);
-        log("getFragmentViewSize()", getFragmentViewSize(string.package_name));
-        log("getWindowSize()", getWindowSize());
 
         //刘海屏
         //(1)假设发生画面裁切时，实际显示画面上下（或左右）被裁切的宽度一样（刘海总宽度的一半），
@@ -4406,37 +4407,6 @@ function getWindowSize() {
     var pt = new Point();
     wm.getDefaultDisplay().getSize(pt);
     return pt;
-}
-
-function getFragmentViewBounds(package_name) {
-    if (package_name == null || package_name == "") {
-        try {
-            throw new Error("getFragmentViewBounds: null/empty package_name");
-        } catch (e) {
-            logException(e);
-        }
-        let sz = getWindowSize();
-        return new android.graphics.Rect(0, 0, sz.x, sz.y);
-    }
-    return selector()
-           .packageName(package_name)
-           .className("android.widget.EditText")
-           .algorithm("BFS")
-           .findOnce()
-           .parent()
-           .bounds();
-}
-function getFragmentViewSize(package_name) {
-    if (package_name == null || package_name == "") {
-        try {
-            throw new Error("getFragmentViewSize: null/empty package_name");
-        } catch (e) {
-            logException(e);
-        }
-        return getWindowSize();
-    }
-    let bounds = getFragmentViewBounds(package_name);
-    return new android.graphics.Point(bounds.width(), bounds.height());
 }
 
 function killBackground(packageName) {

--- a/floatUI.js
+++ b/floatUI.js
@@ -4409,6 +4409,15 @@ function getWindowSize() {
 }
 
 function getFragmentViewBounds(package_name) {
+    if (package_name == null || package_name == "") {
+        try {
+            throw new Error("getFragmentViewBounds: null/empty package_name"
+        } catch (e) {
+            logException(e);
+        }
+        let sz = getWindowSize();
+        return new android.graphics.Rect(0, 0, sz.x, sz.y);
+    }
     return selector()
            .packageName(package_name)
            .className("android.widget.EditText")
@@ -4418,8 +4427,16 @@ function getFragmentViewBounds(package_name) {
            .bounds();
 }
 function getFragmentViewSize(package_name) {
+    if (package_name == null || package_name == "") {
+        try {
+            throw new Error("getFragmentViewSize: null/empty package_name"
+        } catch (e) {
+            logException(e);
+        }
+        return getWindowSize();
+    }
     let bounds = getFragmentViewBounds(package_name);
-    return new Point(bounds.width(), bounds.height());
+    return new android.graphics.Point(bounds.width(), bounds.height());
 }
 
 function killBackground(packageName) {

--- a/floatUI.js
+++ b/floatUI.js
@@ -2435,11 +2435,10 @@ function algo_init() {
         }
         log("detected_screen", detected_screen, "detected_gameoffset", detected_gameoffset);
 
-        let element = selector().packageName(string.package_name).className("android.widget.EditText").algorithm("BFS").findOnce();
-        log("EditText bounds", element.bounds());
-        element = element.parent();
-        detected_gamebounds = element.bounds();
+        detected_gamebounds = getFragmentViewBounds(string.package_name);
         log("detected_gamebounds", detected_gamebounds);
+        log("getFragmentViewSize()", getFragmentViewSize(string.package_name));
+        log("getWindowSize()", getWindowSize());
 
         //刘海屏
         //(1)假设发生画面裁切时，实际显示画面上下（或左右）被裁切的宽度一样（刘海总宽度的一半），
@@ -4392,6 +4391,20 @@ function getWindowSize() {
     var pt = new Point();
     wm.getDefaultDisplay().getSize(pt);
     return pt;
+}
+
+function getFragmentViewBounds(package_name) {
+    return selector()
+           .packageName(package_name)
+           .className("android.widget.EditText")
+           .algorithm("BFS")
+           .findOnce()
+           .parent()
+           .bounds();
+}
+function getFragmentViewSize(package_name) {
+    let bounds = getFragmentViewBounds(package_name);
+    return new Point(bounds.width(), bounds.height());
 }
 
 function killBackground(packageName) {

--- a/floatUI.js
+++ b/floatUI.js
@@ -4411,7 +4411,7 @@ function getWindowSize() {
 function getFragmentViewBounds(package_name) {
     if (package_name == null || package_name == "") {
         try {
-            throw new Error("getFragmentViewBounds: null/empty package_name"
+            throw new Error("getFragmentViewBounds: null/empty package_name");
         } catch (e) {
             logException(e);
         }
@@ -4429,7 +4429,7 @@ function getFragmentViewBounds(package_name) {
 function getFragmentViewSize(package_name) {
     if (package_name == null || package_name == "") {
         try {
-            throw new Error("getFragmentViewSize: null/empty package_name"
+            throw new Error("getFragmentViewSize: null/empty package_name");
         } catch (e) {
             logException(e);
         }

--- a/floatUI.js
+++ b/floatUI.js
@@ -2506,6 +2506,21 @@ function algo_init() {
             selector().depth(0).findOnce();//弹出申请开启无障碍服务的弹窗
         }
 
+        if ($settings.isEnabled("stable_mode")) {
+            toastLog("警告: 发现AutoJS的无障碍服务\"稳定模式\"被开启!\n\"稳定模式\"会干扰控件信息抓取!\n尝试关闭...");
+            $settings.setEnabled("stable_mode", false);
+            if (device.sdkInt >= 24) {
+                auto.service.disableSelf();
+                toastLog("为了关闭\"稳定模式\",已停用无障碍服务\n请重新启用无障碍服务后继续");
+            } else {
+                toastLog("为了关闭\"稳定模式\",\nAndroid 6.0或以下,请到系统设置里:\n先停用无障碍服务,再重新启用");
+            }
+            app.startActivity({
+                action: "android.settings.ACCESSIBILITY_SETTINGS"
+            });
+            stopThread();
+        }
+
         //检测区服
         if (detectGameLang() == null) {
             if (!dontStopOnError) {

--- a/main.js
+++ b/main.js
@@ -360,7 +360,10 @@ ui.autoService.setOnCheckedChangeListener(function (widget, checked) {
         if (device.sdkInt >= 24) {
             auto.service.disableSelf();
         } else {
-            toastLog("Android 6.0或以下请到系统设置里关闭无障碍服务");
+            toastLog("Android 6.0或以下请到系统设置里手动关闭无障碍服务");
+            app.startActivity({
+                action: "android.settings.ACCESSIBILITY_SETTINGS"
+            });
         }
     }
     ui.autoService.setChecked(auto.service != null)


### PR DESCRIPTION
“稳定模式”下控件信息抓取不全，比如`id`为`android:id/content`的控件就抓不到（实际上存在，关闭“稳定模式”就又可以抓到），然后就导致STATE_TEAM迟迟不会切换到STATE_BATTLE