### PR TITLE
脚本启动时另开一个线程反复检测刘海屏参数,4秒后超时退出

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -656,14 +656,20 @@ floatUI.main = function () {
         //Android 8.1或以下没有刘海屏API,无法检测
         if (device.sdkInt < 28) return;
 
-        cutoutParamsLock.lock();
-        var startTime = new Date().getTime();
-        do {
-            try {adjustCutoutParams();} catch (e) {logException(e);};
-            if (limit.cutoutParams != null && limit.cutoutParams.cutout != null) break;
-            sleep(500);
-        } while (new Date().getTime() < startTime + 4000);
-        cutoutParamsLock.unlock();
+        try {
+            cutoutParamsLock.lock();
+            var startTime = new Date().getTime();
+            do {
+                try {adjustCutoutParams();} catch (e) {logException(e);};
+                if (limit.cutoutParams != null && limit.cutoutParams.cutout != null) break;
+                sleep(500);
+            } while (new Date().getTime() < startTime + 4000);
+        } catch (e) {
+            logException(e);
+            throw e;
+        } finally {
+            cutoutParamsLock.unlock();
+        }
         log("limit.cutoutParams", limit.cutoutParams);
     });
 
@@ -2463,10 +2469,16 @@ function algo_init() {
         if (device.sdkInt >= 28) {
             //Android 9或以上有原生的刘海屏API
             //处理转屏
-            cutoutParamsLock.lock();
-            var initialRotation = limit.cutoutParams != null ? limit.cutoutParams.rotation : null;
-            var initialCutout = limit.cutoutParams != null ? limit.cutoutParams.cutout : null;
-            cutoutParamsLock.unlock();
+            try {
+                cutoutParamsLock.lock();
+                var initialRotation = limit.cutoutParams != null ? limit.cutoutParams.rotation : null;
+                var initialCutout = limit.cutoutParams != null ? limit.cutoutParams.cutout : null;
+            } catch (e) {
+                logException(e);
+                throw e;
+            } finally {
+                cutoutParamsLock.unlock();
+            }
             if (initialRotation != null && initialCutout != null) {
                 let display = context.getSystemService(android.content.Context.WINDOW_SERVICE).getDefaultDisplay();
                 let currentRotation = display.getRotation();


### PR DESCRIPTION
在log里有发现明明是Android 9以上（Android 11）却仍然时不时就未能成功获取到刘海屏参数的情况

（其实这里说的是getDisplayCutout没获取到的情况，这个时候其实一般问题也不大，因为还可以通过游戏FragmentView来推算刘海信息）

```
2021-06-26 20:55:34.183/DEBUG: 执行 副本周回（剧情，活动通用） 脚本
2021-06-26 20:55:34.242/DEBUG: 区服 zh_Hans
2021-06-26 20:55:34.252/DEBUG: detected_screen { width: 2340, height: 1080, type: 'wider' } detected_gameoffset { x: 210, y: 0, center: { y: 0 }, bottom: { y: 0 } }
2021-06-26 20:55:34.579/DEBUG: EditText bounds Rect(255, 0 - 2175, 132)
2021-06-26 20:55:34.580/DEBUG: detected_gamebounds Rect(255, 0 - 2175, 1080)
2021-06-26 20:55:34.581/DEBUG: currentRotation 1 initialRotation 0
2021-06-26 20:55:34.581/DEBUG: relativeRotation 1
2021-06-26 20:55:34.583/DEBUG: safeInsets before rotation { Left: 0, Top: 90, Right: 0, Bottom: 0 }
2021-06-26 20:55:34.585/DEBUG: safeInsets after rotation { Left: 90, Top: 0, Right: 0, Bottom: 0 }
2021-06-26 20:55:34.585/DEBUG: isGameoffsetAdjusted true
2021-06-26 20:55:34.588/DEBUG: detected_gameoffset { x: 255, y: 0, center: { y: 0 }, bottom: { y: 0 } }

...

2021-06-26 21:16:17.101/DEBUG: AutoBattle v4.0.0
2021-06-26 21:16:17.112/DEBUG: 
参数:
 { version: '4.0.0',
  helpx: '',
  helpy: '',
  battleNo: 'cb3',
  drug1: true,
  drug2: false,
  drug3: false,
  autoReconnect: true,
  justNPC: false,
  drug4: false,
  drug1num: '',
  drug2num: '0',
  drug3num: '0',
  drug4num: '0',
  default: 10,
  useAuto: true,
  breakAutoCycleDuration: '',
  forceStopTimeout: '',
  apmul: '',
  timeout: '5000',
  rootScreencap: false,
  rootForceStop: false,
  firstRequestPrivilege: true,
  privilege: null,
  cutoutParams: 
   { rotation: 0,
     cutout: DisplayCutout{insets=Rect(0, 90 - 0, 0) waterfall=Insets{left=0, top=0, right=0, bottom=0} boundingRect={Bounds=[Rect(0, 0 - 0, 0), Rect(0, 0 - 177, 90), Rect(0, 0 - 0, 0), Rect(0, 0 - 0, 0)]}} } }
2021-06-26 21:16:17.112/DEBUG: Android API Level 30
2021-06-26 21:16:17.112/DEBUG: 屏幕分辨率 1080 2340
2021-06-26 21:16:17.112/DEBUG: 
brand Xiaomi
device cas
model M2007J1SC
product cas
hardware qcom

...

2021-06-26 21:52:44.213/DEBUG: 执行 副本周回（剧情，活动通用） 脚本
2021-06-26 21:52:44.254/DEBUG: detected_screen { width: 2340, height: 1080, type: 'wider' } detected_gameoffset { x: 210, y: 0, center: { y: 0 }, bottom: { y: 0 } }
2021-06-26 21:52:44.486/DEBUG: EditText bounds Rect(255, 0 - 2175, 132)
2021-06-26 21:52:44.495/DEBUG: detected_gamebounds Rect(255, 0 - 2175, 1080)
2021-06-26 21:52:44.495/DEBUG: isGameoffsetAdjusted false
2021-06-26 21:52:44.497/DEBUG: detected_gameoffset { x: 255, y: 0, center: { y: 0 }, bottom: { y: 0 } }
```