### PR TITLE
修正getWindowSize搞错转屏方向的问题

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -957,6 +957,9 @@ floatUI.main = function () {
         return {pos_down: touch_down_pos, pos_up: touch_up_pos, duration: swipe_duration};
     };
 
+    //初始化getWindowSize()
+    detectInitialWindowSize();
+
     //检测刘海屏参数
     function adjustCutoutParams() {
         if (device.sdkInt >= 28) {
@@ -5014,10 +5017,31 @@ function algo_init() {
 }
 
 //global utility functions
+var initialWindowSize = {};
+function detectInitialWindowSize() {
+    let display = context.getSystemService(context.WINDOW_SERVICE).getDefaultDisplay();
+
+    let pt = new Point();
+    display.getSize(pt);
+
+    let rotation = display.getRotation();
+
+    initialWindowSize = {size: pt, rotation: rotation};
+}
 function getWindowSize() {
-    var wm = context.getSystemService(context.WINDOW_SERVICE);
-    var pt = new Point();
-    wm.getDefaultDisplay().getSize(pt);
+    let display = context.getSystemService(context.WINDOW_SERVICE).getDefaultDisplay();
+    let currentRotation = display.getRotation();
+    let relativeRotation = (4 + currentRotation - initialWindowSize.rotation) % 4;
+
+    let x = initialWindowSize.size.x;
+    let y = initialWindowSize.size.y;
+    if (relativeRotation % 2 == 1) {
+        let temp = x;
+        x = y;
+        y = temp;
+    }
+
+    let pt = new Point(x, y);
     return pt;
 }
 


### PR DESCRIPTION
在MIUI 12.5上发现这个问题，不知道别的环境是什么样

有的时候返回的是转屏后的分辨率，有的时候不是，于是就导致故障，包括脚本选择悬浮窗窝在左下角显示不全、点击坐标捕获悬浮窗只覆盖屏幕半边等等。

解决方法就是脚本启动时记录一个初始的屏幕宽高值和转屏方向，后续调用时根据当前转屏方向来旋转屏幕宽高值。

#78 其实很大程度上就是这个问题导致的。