### PR TITLE
修正报告问题崩溃的问题

### DIFF
--- a/main.js
+++ b/main.js
@@ -243,7 +243,7 @@ function reportBug() {
 
     var snapshotDir = files.join(files.getSdcardPath(), "auto_magireco");
     var listedFilenames = files.listDir(snapshotDir, function (filename) {
-        return filename.match(/^\d+-\d+-\d+_\d+-\d+-\d+\.xml$/) && files.isFile(files.join(snapshotDir, filename));
+        return filename.match(/^\d+-\d+-\d+_\d+-\d+-\d+\.xml$/) != null && files.isFile(files.join(snapshotDir, filename));
     });
     var latest = [0,0,0,0,0,0];
     if (listedFilenames != null) {


### PR DESCRIPTION
如果/sdcard/auto_magireco/里有其他不是快照的东西就会触发

```
2021-07-14 23:03:54.225/ERROR: Thread[main,5]: Cannot convert null to boolean (main.js#245)
Cannot convert null to boolean
    at reportBug (main.js:245:0)
```