### PR TITLE
优化速度

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -2244,14 +2244,14 @@ function algo_init() {
                 auto.root.refresh();
             } catch (e) {
                 logException(e);
-                if (wait) sleep(isFast ? 16 : 100);
+                if (wait) sleep(isFast ? 32 : 100);
                 continue;
             }
             result = textMatches(reg).findOnce();
             if (result && (isFast || result.refresh())) break;
             result = descMatches(reg).findOnce();
             if (result && (isFast || result.refresh())) break;
-            if (wait) sleep(isFast ? 16 : 100);
+            if (wait) sleep(isFast ? 32 : 100);
         } while (wait === true || (wait && new Date().getTime() < startTime + wait));
         return result;
     }
@@ -2298,14 +2298,14 @@ function algo_init() {
                 auto.root.refresh();
             } catch (e) {
                 logException(e);
-                if (wait) sleep(isFast ? 16 : 100);
+                if (wait) sleep(isFast ? 32 : 100);
                 continue;
             }
             result = text(txt).findOnce();
             if (result && (isFast || result.refresh())) break;
             result = desc(txt).findOnce();
             if (result && (isFast || result.refresh())) break;
-            if (wait) sleep(isFast ? 16 : 100);
+            if (wait) sleep(isFast ? 32 : 100);
         } while (wait === true || (wait && new Date().getTime() < startTime + wait));
         return result;
     }
@@ -2351,12 +2351,12 @@ function algo_init() {
                 auto.root.refresh();
             } catch (e) {
                 logException(e);
-                if (wait) sleep(isFast ? 16 : 100);
+                if (wait) sleep(isFast ? 32 : 100);
                 continue;
             }
             result = id(name).findOnce();
             if (result && (isFast || result.refresh())) break;
-            if (wait) sleep(isFast ? 16 : 100);
+            if (wait) sleep(isFast ? 32 : 100);
         } while (wait === true || (wait && new Date().getTime() < startTime + wait));
         return result;
     }
@@ -2407,7 +2407,7 @@ function algo_init() {
             result = fnlist[current]();
             if (result && (isFast || result.refresh())) break;
             current++;
-            sleep(isFast ? 16 : 50);
+            sleep(isFast ? 32 : 50);
         } while (wait === true || (wait && new Date().getTime() < startTime + wait));
         if (wait)
             log(

--- a/floatUI.js
+++ b/floatUI.js
@@ -2434,6 +2434,7 @@ function algo_init() {
 
     //AP回复、更改队伍名称、连线超时等弹窗都属于这种类型
     //关注追加窗口在MuMu上点这里的close坐标点不到关闭
+    //title_to_find可以是数组
     function findPopupInfoDetailTitle(title_to_find, wait) {
         let default_x = getFragmentViewBounds().right - 1;
         let default_y = 0;
@@ -2477,7 +2478,17 @@ function algo_init() {
             result.title = "";
         }
 
-        if (title_to_find != null && result.title != title_to_find) return null;
+        if (
+             title_to_find != null
+             && (
+                  typeof title_to_find == "string"
+                  ? title_to_find != result.title
+                  : title_to_find.find((val) => val == result.title) == null
+                )
+           )
+        {
+            return null;
+        }
 
         let element_bounds = element.bounds();
         let half_height = parseInt(element_bounds.height() / 2);
@@ -3199,16 +3210,13 @@ function algo_init() {
 
         do {
             let found_popup = null;
-            for (let error_type of ["connection_lost", "auth_error", "generic_error"]) {
-                try {
-                    found_popup = findPopupInfoDetailTitle(string[error_type]);
-                } catch (e) {
-                    logException(e);
-                    found_popup = null;
-                }
-                if (found_popup != null) break;
+            try {
+                found_popup = findPopupInfoDetailTitle(["connection_lost", "auth_error", "generic_error"]);
+            } catch (e) {
+                logException(e);
+                found_popup = null;
             }
-            if (found_popup) {
+            if (found_popup != null) {
                 log("游戏已经断线/登出/出错,并强制回首页");
                 return "logged_out";
             }

--- a/floatUI.js
+++ b/floatUI.js
@@ -309,6 +309,8 @@ function getStatusText() {
 //监视当前任务的线程
 var monitoredTask = null;
 
+var bypassPopupCheck = threads.atomic(0);
+
 var syncedReplaceCurrentTask = sync(function(taskItem, callback) {
     if (currentTask != null && currentTask.isAlive()) {
         stopThread(currentTask);
@@ -3182,7 +3184,6 @@ function algo_init() {
 
     //检测游戏是否闪退或掉线
     //注意！调用后会重新检测区服，从而可能导致string、last_alive_lang变量被重新赋值
-    var bypassPopupCheck = threads.atomic(0);
     function isGameDead(wait) {
         var startTime = new Date().getTime();
         var detectedLang = null;

--- a/floatUI.js
+++ b/floatUI.js
@@ -336,6 +336,8 @@ var syncedReplaceCurrentTask = sync(function(taskItem, callback) {
             isCurrentTaskPaused.set(TASK_STOPPED);
             lockUI(false);
         }
+        //之前可能在STATE_TEAM状态下设置了跳过isGameDead里的掉线弹窗检查,现在恢复成不跳过
+        bypassPopupCheck.set(0);
         log("关闭所有无主对话框...");
         try {
             openedDialogsLock.lock();//先加锁，dismiss会等待解锁后再开始删
@@ -3180,7 +3182,7 @@ function algo_init() {
 
     //检测游戏是否闪退或掉线
     //注意！调用后会重新检测区服，从而可能导致string、last_alive_lang变量被重新赋值
-    var bypassPopupCheck = false;
+    var bypassPopupCheck = threads.atomic(0);
     function isGameDead(wait) {
         var startTime = new Date().getTime();
         var detectedLang = null;
@@ -3210,7 +3212,7 @@ function algo_init() {
         }
 
         //因为STATE_TEAM状态下这里的掉线弹窗检查非常慢,所以跳过头4回检查
-        if (!bypassPopupCheck) do {
+        if (bypassPopupCheck.get() == 0) do {
             let found_popup = null;
             try {
                 found_popup = findPopupInfoDetailTitle(["connection_lost", "auth_error", "generic_error"]);
@@ -5137,13 +5139,13 @@ function algo_init() {
             if (state == STATE_TEAM) {
                 if (last_state != STATE_TEAM) bypassPopupCheckCounter = 4;
                 if (bypassPopupCheckCounter-- > 0) {
-                    bypassPopupCheck = true;
+                    bypassPopupCheck.set(1);
                 } else {
-                    bypassPopupCheck = false;
+                    bypassPopupCheck.set(0);
                 }
             } else {
                 bypassPopupCheckCounter = 0;
-                bypassPopupCheck = false;
+                bypassPopupCheck.set(0);
             }
             if (state != STATE_CRASHED && state != STATE_LOGIN && isGameDead(false)) {
                 if (lastOpList != null) {

--- a/floatUI.js
+++ b/floatUI.js
@@ -3225,7 +3225,8 @@ function algo_init() {
         return false;
     }
 
-    function getFragmentViewBounds() {
+    var lastFragmentViewStatus = {bounds: null, rotation: 0};
+    var getFragmentViewBounds = sync(function () {
         if (string == null || string.package_name == null || string.package_name == "") {
             try {
                 throw new Error("getFragmentViewBounds: null/empty string.package_name");
@@ -3233,8 +3234,17 @@ function algo_init() {
                 logException(e);
             }
             let sz = getWindowSize();
+            lastFragmentViewStatus = {bounds: null, rotation: 0};
             return new android.graphics.Rect(0, 0, sz.x, sz.y);
         }
+
+        //复用上次的结果,加快速度
+        let display = context.getSystemService(android.content.Context.WINDOW_SERVICE).getDefaultDisplay();
+        let currentRotation = display.getRotation();
+        if (lastFragmentViewStatus.bounds != null && lastFragmentViewStatus.rotation == currentRotation) {
+            return lastFragmentViewStatus.bounds;
+        }
+
         let bounds = null;
         try {
             bounds = selector()
@@ -3248,10 +3258,14 @@ function algo_init() {
             logException(e);
             log("getFragmentViewBounds出错,使用getWindowSize作为替代");
             let sz = getWindowSize();
+            lastFragmentViewStatus = {bounds: null, rotation: 0};
             return new android.graphics.Rect(0, 0, sz.x, sz.y);
         }
+
+        if (bounds != null) lastFragmentViewStatus = {bounds: bounds, rotation: currentRotation};
+
         return bounds;
-    }
+    });
 
     var screen = {width: 0, height: 0, type: "normal"};
     var gamebounds = null;

--- a/floatUI.js
+++ b/floatUI.js
@@ -3180,6 +3180,7 @@ function algo_init() {
 
     //检测游戏是否闪退或掉线
     //注意！调用后会重新检测区服，从而可能导致string、last_alive_lang变量被重新赋值
+    var bypassPopupCheck = false;
     function isGameDead(wait) {
         var startTime = new Date().getTime();
         var detectedLang = null;
@@ -3208,7 +3209,8 @@ function algo_init() {
             return "crashed";
         }
 
-        do {
+        //因为STATE_TEAM状态下这里的掉线弹窗检查非常慢,所以跳过头4回检查
+        if (!bypassPopupCheck) do {
             let found_popup = null;
             try {
                 found_popup = findPopupInfoDetailTitle(["connection_lost", "auth_error", "generic_error"]);
@@ -5099,6 +5101,7 @@ function algo_init() {
         var lastReLaunchTime = new Date().getTime();
         var isFirstBRANCHClick = true; //在杜鹃花型活动地图点了启动脚本,无法保证一定能正确选关
         var BRANCHclickAttemptCount = 0;
+        var bypassPopupCheckCounter = 0;
         /*
         //实验发现，在战斗之外环节掉线会让游戏重新登录回主页，无法直接重连，所以注释掉
         var stuckatreward = false;
@@ -5130,6 +5133,18 @@ function algo_init() {
             }
 
             //然后检测游戏是否闪退或掉线
+            //因为STATE_TEAM状态下isGameDead里的掉线弹窗检查非常慢,故跳过头4回检查
+            if (state == STATE_TEAM) {
+                if (last_state != STATE_TEAM) bypassPopupCheckCounter = 4;
+                if (bypassPopupCheckCounter-- > 0) {
+                    bypassPopupCheck = true;
+                } else {
+                    bypassPopupCheck = false;
+                }
+            } else {
+                bypassPopupCheckCounter = 0;
+                bypassPopupCheck = false;
+            }
             if (state != STATE_CRASHED && state != STATE_LOGIN && isGameDead(false)) {
                 if (lastOpList != null) {
                     state = STATE_CRASHED;


### PR DESCRIPTION
在MuMu模拟器中，现在感觉就队伍调整（STATE_TEAM）那个时候最慢（其实游戏本身那几秒钟也挺卡），尝试优化一下：

1. 让findPopupInfoDetailTitle可以接受数组作为匹配条件
2. 保存上一次getFragmentViewBounds的结果来加快速度
3. STATE_TEAM状态下跳过头4回掉线弹窗检查