### PR TITLE
【填坑中】更换脚本设置界面为webview

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "autoWebview"]
+	path = autoWebview
+	url = https://github.com/segfault-bilibili/autoWebview/

--- a/floatUI.js
+++ b/floatUI.js
@@ -3151,6 +3151,7 @@ function algo_init() {
 
     //检测游戏是否闪退或掉线
     //注意！调用后会重新检测区服，从而可能导致string、last_alive_lang变量被重新赋值
+    var bypassPopupCheck = false;
     function isGameDead(wait) {
         var startTime = new Date().getTime();
         var detectedLang = null;
@@ -3179,7 +3180,8 @@ function algo_init() {
             return "crashed";
         }
 
-        do {
+        //因为STATE_TEAM状态下这里的掉线弹窗检查非常慢,所以跳过头4回检查
+        if (!bypassPopupCheck) do {
             let found_popup = null;
             try {
                 found_popup = findPopupInfoDetailTitle(["connection_lost", "auth_error", "generic_error"]);
@@ -5070,6 +5072,7 @@ function algo_init() {
         var lastReLaunchTime = new Date().getTime();
         var isFirstBRANCHClick = true; //在杜鹃花型活动地图点了启动脚本,无法保证一定能正确选关
         var BRANCHclickAttemptCount = 0;
+        var bypassPopupCheckCounter = 0;
         /*
         //实验发现，在战斗之外环节掉线会让游戏重新登录回主页，无法直接重连，所以注释掉
         var stuckatreward = false;
@@ -5101,6 +5104,18 @@ function algo_init() {
             }
 
             //然后检测游戏是否闪退或掉线
+            //因为STATE_TEAM状态下isGameDead里的掉线弹窗检查非常慢,故跳过头4回检查
+            if (state == STATE_TEAM) {
+                if (last_state != STATE_TEAM) bypassPopupCheckCounter = 4;
+                if (bypassPopupCheckCounter-- > 0) {
+                    bypassPopupCheck = true;
+                } else {
+                    bypassPopupCheck = false;
+                }
+            } else {
+                bypassPopupCheckCounter = 0;
+                bypassPopupCheck = false;
+            }
             if (state != STATE_CRASHED && state != STATE_LOGIN && isGameDead(false)) {
                 if (lastOpList != null) {
                     state = STATE_CRASHED;

--- a/floatUI.js
+++ b/floatUI.js
@@ -5875,11 +5875,25 @@ function algo_init() {
                 log("检测到横屏强制转竖屏的截屏");
                 needScreenCaptureFix = true;
             }
+            log("检测是否返回了空白图像...");
+            let isBlank = false;
+            for (let c of [colors.BLACK, colors.WHITE]) {
+                let p = images.findColor(screenshot, c, {threshold: 254});
+                if (p == null) {
+                    isBlank = true;
+                    break;
+                }
+            }
+            if (isBlank) {
+                toastLog("录屏API似乎返回了空白图像,\n脚本将停止运行。\n请使用root或adb权限截屏");
+                throw new Error("initializeScreenCaptureFix detected blank screenshot");
+            } else {
+                log("检测完成,并不是空白图像");
+            }
         } catch (e) {
             hasScreenCaptureError = true;
             toastLog("通过录屏API截图时出错\n请使用root或adb权限截屏");
-            logException(e);
-            stopThread();
+            throw e;
         }
     }
 

--- a/floatUI.js
+++ b/floatUI.js
@@ -2215,14 +2215,14 @@ function algo_init() {
                 auto.root.refresh();
             } catch (e) {
                 logException(e);
-                if (wait) sleep(isFast ? 16 : 100);
+                if (wait) sleep(isFast ? 32 : 100);
                 continue;
             }
             result = textMatches(reg).findOnce();
             if (result && (isFast || result.refresh())) break;
             result = descMatches(reg).findOnce();
             if (result && (isFast || result.refresh())) break;
-            if (wait) sleep(isFast ? 16 : 100);
+            if (wait) sleep(isFast ? 32 : 100);
         } while (wait === true || (wait && new Date().getTime() < startTime + wait));
         return result;
     }
@@ -2269,14 +2269,14 @@ function algo_init() {
                 auto.root.refresh();
             } catch (e) {
                 logException(e);
-                if (wait) sleep(isFast ? 16 : 100);
+                if (wait) sleep(isFast ? 32 : 100);
                 continue;
             }
             result = text(txt).findOnce();
             if (result && (isFast || result.refresh())) break;
             result = desc(txt).findOnce();
             if (result && (isFast || result.refresh())) break;
-            if (wait) sleep(isFast ? 16 : 100);
+            if (wait) sleep(isFast ? 32 : 100);
         } while (wait === true || (wait && new Date().getTime() < startTime + wait));
         return result;
     }
@@ -2322,12 +2322,12 @@ function algo_init() {
                 auto.root.refresh();
             } catch (e) {
                 logException(e);
-                if (wait) sleep(isFast ? 16 : 100);
+                if (wait) sleep(isFast ? 32 : 100);
                 continue;
             }
             result = id(name).findOnce();
             if (result && (isFast || result.refresh())) break;
-            if (wait) sleep(isFast ? 16 : 100);
+            if (wait) sleep(isFast ? 32 : 100);
         } while (wait === true || (wait && new Date().getTime() < startTime + wait));
         return result;
     }
@@ -2378,7 +2378,7 @@ function algo_init() {
             result = fnlist[current]();
             if (result && (isFast || result.refresh())) break;
             current++;
-            sleep(isFast ? 16 : 50);
+            sleep(isFast ? 32 : 50);
         } while (wait === true || (wait && new Date().getTime() < startTime + wait));
         if (wait)
             log(

--- a/floatUI.js
+++ b/floatUI.js
@@ -5715,12 +5715,13 @@ function algo_init() {
                         state = STATE_BATTLE;
                         break;
                     }
-                    // try to skip
-                    if (!id("menu").findOnce()) {
-                        //这里开发者意见存在分歧
-                        // @icegreentee 认为这样最简单直接,实际上也观察到之前有误触菜单问题的用户不再反馈有这个问题
-                        // @segfault-bilibili 观察到menu控件无论主菜单是否打开都存在,所以怀疑这个检测的效果
-                        // 实际测试发现确实有效果,现在怀疑是不是和QQ等在屏幕上弹出通知有关
+                    //点击跳过剧情
+                    //出现这些控件中的任何一个即说明已经跳过剧情，然后就可以避免误触MENU。
+                    //有时候单单靠上面getAP检测AP余量控件是否出现还不够，还是可能偶发误触MENU按钮，
+                    //因为AP余量控件可能会概率性玄学消失（用Android SDK里的UI Automator Viewer工具抓到的布局里也完全缺失这个控件）
+                    //因此，只能尽量多检测几个控件id来尽可能降低误触MENU的风险。
+                    let IDsToFind = ["menu", "helpBtn", "sideMenu", "menuBtns", "sideBigBtns"];
+                    if (!IDsToFind.find((val) => id(val).findOnce() != null)) {
                         log("尝试跳过剧情");
                         click(convertCoords(clickSets.skip));
                     }

--- a/floatUI.js
+++ b/floatUI.js
@@ -1099,8 +1099,9 @@ floatUI.main = function () {
             logstring = "执行shell命令: ["+shellcmd+"]";
         if (logstring !== false) log("直接使用root权限"+logstring);
         $shell.setDefaultOptions({adb: false});
+        let result = $shell(shellcmd, true);
         if (logstring !== false) log("直接使用root权限"+logstring+" 完成");
-        return $shell(shellcmd, true);
+        return result;
     };
     //根据情况使用Shizuku还是直接使用root执行shell命令
     privShell = function (shellcmd, logstring) {
@@ -1125,8 +1126,9 @@ floatUI.main = function () {
             logstring = "执行shell命令: ["+shellcmd+"]";
         if (logstring !== false) log("不使用特权"+logstring);
         $shell.setDefaultOptions({adb: false});
+        let result = $shell(shellcmd);
         if (logstring !== false) log("不使用特权"+logstring+" 完成");
-        return $shell(shellcmd);
+        return result;
     }
 
     //检查并申请root或adb权限

--- a/floatUI.js
+++ b/floatUI.js
@@ -2405,6 +2405,7 @@ function algo_init() {
 
     //AP回复、更改队伍名称、连线超时等弹窗都属于这种类型
     //关注追加窗口在MuMu上点这里的close坐标点不到关闭
+    //title_to_find可以是数组
     function findPopupInfoDetailTitle(title_to_find, wait) {
         let default_x = getFragmentViewBounds().right - 1;
         let default_y = 0;
@@ -2448,7 +2449,17 @@ function algo_init() {
             result.title = "";
         }
 
-        if (title_to_find != null && result.title != title_to_find) return null;
+        if (
+             title_to_find != null
+             && (
+                  typeof title_to_find == "string"
+                  ? title_to_find != result.title
+                  : title_to_find.find((val) => val == result.title) == null
+                )
+           )
+        {
+            return null;
+        }
 
         let element_bounds = element.bounds();
         let half_height = parseInt(element_bounds.height() / 2);
@@ -3170,16 +3181,13 @@ function algo_init() {
 
         do {
             let found_popup = null;
-            for (let error_type of ["connection_lost", "auth_error", "generic_error"]) {
-                try {
-                    found_popup = findPopupInfoDetailTitle(string[error_type]);
-                } catch (e) {
-                    logException(e);
-                    found_popup = null;
-                }
-                if (found_popup != null) break;
+            try {
+                found_popup = findPopupInfoDetailTitle(["connection_lost", "auth_error", "generic_error"]);
+            } catch (e) {
+                logException(e);
+                found_popup = null;
             }
-            if (found_popup) {
+            if (found_popup != null) {
                 log("游戏已经断线/登出/出错,并强制回首页");
                 return "logged_out";
             }

--- a/floatUI.js
+++ b/floatUI.js
@@ -506,7 +506,7 @@ floatUI.main = function () {
         replaceCurrentTask({name:"未运行任何脚本", fn: function () {}});
     }
 
-    //检测getRotation获取到的转屏方向是不是出现错误
+    //检测getWindowSize的转屏方向是不是出现错误
     function checkRotationGlitch() {
         let sz = getWindowSize();
         if (sz.y > sz.x) {
@@ -926,7 +926,7 @@ floatUI.main = function () {
                     task_popup.setPosition(sz.x / 4, sz.y / 4);
                 } catch (e) {
                     logException(e);
-                    //貌似只有完全退出脚本才可以避免getRotation错位的问题
+                    //貌似只有完全退出脚本才可以避免getWindowSize屏幕方向错位的问题
                     toastLog("无法重设悬浮窗的大小和位置,\n可能是悬浮窗意外消失\n退出脚本...");
                     limit.killSelf = true;//杀死自己的两个后台进程
                     engines.stopAll();
@@ -1069,9 +1069,6 @@ floatUI.main = function () {
         let swipe_duration = touch_up_time - touch_down_time;
         return {pos_down: touch_down_pos, pos_up: touch_up_pos, duration: swipe_duration};
     };
-
-    //初始化getWindowSize()
-    detectInitialWindowSize();
 
     //检测刘海屏参数
     function adjustCutoutParams() {
@@ -9185,18 +9182,27 @@ function algo_init() {
 
 //global utility functions
 //MIUI上发现有时候转屏了getSize返回的还是没转屏的数据，但getRotation的结果仍然是转过屏的，所以 #89 才改成这样
-var initialWindowSize = {};
+var initialWindowSize = {initialized: false};
 function detectInitialWindowSize() {
-    let display = context.getSystemService(context.WINDOW_SERVICE).getDefaultDisplay();
+    ui.run(function () {
+        if (initialWindowSize.initialized) return;
 
-    let pt = new Point();
-    display.getSize(pt);
+        let initialSize = new Point();
+        try {
+            let mWm = android.view.IWindowManager.Stub.asInterface(android.os.ServiceManager.checkService(android.content.Context.WINDOW_SERVICE));
+            mWm.getInitialDisplaySize(android.view.Display.DEFAULT_DISPLAY, initialSize);
+        } catch (e) {
+            logException(e);
+            toastLog("无法获取屏幕物理分辨率\n请尝试以竖屏模式重启");
+            initialSize = new Point(device.width, device.height);
+        }
 
-    let rotation = display.getRotation();
-
-    initialWindowSize = {size: pt, rotation: rotation};
-}
+        initialWindowSize = {size: initialSize, rotation: 0, initialized: true};
+        log("initialWindowSize", initialWindowSize);
+    });
+};
 function getWindowSize() {
+    detectInitialWindowSize();
     let display = context.getSystemService(context.WINDOW_SERVICE).getDefaultDisplay();
     let currentRotation = display.getRotation();
     let relativeRotation = (4 + currentRotation - initialWindowSize.rotation) % 4;

--- a/floatUI.js
+++ b/floatUI.js
@@ -309,6 +309,8 @@ function getStatusText() {
 //监视当前任务的线程
 var monitoredTask = null;
 
+var bypassPopupCheck = threads.atomic(0);
+
 var syncedReplaceCurrentTask = sync(function(taskItem, callback) {
     if (currentTask != null && currentTask.isAlive()) {
         stopThread(currentTask);
@@ -3153,7 +3155,6 @@ function algo_init() {
 
     //检测游戏是否闪退或掉线
     //注意！调用后会重新检测区服，从而可能导致string、last_alive_lang变量被重新赋值
-    var bypassPopupCheck = threads.atomic(0);
     function isGameDead(wait) {
         var startTime = new Date().getTime();
         var detectedLang = null;

--- a/floatUI.js
+++ b/floatUI.js
@@ -8070,14 +8070,6 @@ function algo_init() {
             //我的回合，抽盘
             turn++;
 
-            if (limit.CVAutoBattleClickAllSkills) {
-                if (turn >= 3) {
-                    //一般在第3回合后主动技能才冷却完毕
-                    //闭着眼放出所有主动技能
-                    clickAllSkills();
-                }
-            }
-
             //扫描行动盘和战场信息
             scanDisks();
             scanBattleField("our");
@@ -8191,6 +8183,14 @@ function algo_init() {
                 let advAttrEnemies = [];
                 if (advAttribs.length > 0) advAttrEnemies = getEnemiesByAttrib(advAttribs[0]);
                 if (advAttrEnemies.length > 0) avoidAimAtEnemies(advAttrEnemies);
+            }
+
+            if (limit.CVAutoBattleClickAllSkills) {
+                if (turn >= 3) {
+                    //一般在第3回合后主动技能才冷却完毕
+                    //闭着眼放出所有主动技能
+                    clickAllSkills();
+                }
             }
 
             //提前把不被克制的盘排到前面

--- a/floatUI.js
+++ b/floatUI.js
@@ -926,9 +926,7 @@ floatUI.main = function () {
                     task_popup.setPosition(sz.x / 4, sz.y / 4);
                 } catch (e) {
                     logException(e);
-                    //貌似只有完全退出脚本才可以避免getWindowSize屏幕方向错位的问题
                     toastLog("无法重设悬浮窗的大小和位置,\n可能是悬浮窗意外消失\n退出脚本...");
-                    limit.killSelf = true;//杀死自己的两个后台进程
                     engines.stopAll();
                     return; //不再继续往下执行
                 }
@@ -960,37 +958,12 @@ floatUI.main = function () {
         },
     });
 
-    floatUI.isUpgrading = false;
     context.registerReceiver(receiver, new IntentFilter(Intent.ACTION_CONFIGURATION_CHANGED));
     events.on("exit", function () {
-        log("注销广播接收器...");
         try {
             context.unregisterReceiver(receiver);
         } catch (e) {
             logException(e);
-        }
-        log("注销广播接收器完成");
-
-        //希望这样能避免 #110
-        if (limit.killSelf && !floatUI.isUpgrading) {
-            let mytoast = new android.widget.Toast.makeText(context, "杀死脚本自己的后台...", android.widget.Toast.LENGTH_SHORT);
-            let mytoastcb = new android.widget.Toast.Callback({
-                onToastShown: function () {
-                    threads.start(function () {
-                        sleep(500);
-                        //杀死进程名为 包名 的进程，不杀的话会自动重启另一个进程
-                        let name = context.getPackageName();
-                        log("killBackgroundProcesses(packageName=\""+name+"\")");
-                        context.getSystemService(context.ACTIVITY_SERVICE).killBackgroundProcesses(name);
-                        //杀死进程名为 包名:script 的进程
-                        let pid = android.os.Process.myPid();
-                        log("killProcess(pid="+pid+")");
-                        android.os.Process.killProcess(pid);
-                    }).waitFor();
-                }
-            });
-            mytoast.addCallback(mytoastcb);
-            mytoast.show();
         }
     });
 
@@ -1375,7 +1348,6 @@ var limit = {
     CVAutoBattleDebug: false,
     CVAutoBattleClickAllSkills: true,
     firstRequestPrivilege: true,
-    killSelf: false,
     privilege: null
 }
 

--- a/main.js
+++ b/main.js
@@ -105,6 +105,9 @@ ui.layout(
                             </vertical>
                             <Switch id="justNPC" w="*" margin="0 5" checked="false" textColor="#000000" text="只使用NPC(不选则先互关好友,后NPC)" />
                             <Switch id="autoReconnect" w="*" margin="0 3" checked="false" textColor="#000000" text="防断线模式(尽可能自动点击断线重连按钮)" />
+                            <vertical padding="0 3 0 0" w="*" h="auto">
+                                <text textColor="#000000" text="防断线模式仅限于在战斗中自动点击断线重连按钮,无法应对强制回首页的情况。闪退自动重开可以应对强制回首页。" />
+                            </vertical>
                         </vertical>
                     </vertical>
                     <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
@@ -122,11 +125,11 @@ ui.layout(
                             <vertical padding="0 8 0 0" w="*" h="auto">
                                 <Switch id="toggleDefaultExtraSettings" w="*" margin="0 3" checked="false" textColor="#666666" text="显示更多选项" />
                             </vertical>
-                            <vertical id="DefaultExtraSettings1" visibility="gone" padding="0 8 0 0" w="*" h="auto">
+                            <vertical id="DefaultExtraSettings1" visibility="gone" padding="10 8 0 0" w="*" h="auto">
                                 <Switch id="autoFollow" w="*" margin="0 3" checked="true" textColor="#000000" text="自动关注路人" />
                                 <text text="启用后如果助战选到了路人,会在结算时关注他。停用这个选项则不会关注路人,在结算时如果出现询问关注的弹窗,会直接关闭。" textColor="#000000" />
                             </vertical>
-                            <vertical id="DefaultExtraSettings2" visibility="gone" padding="0 8 0 0" w="*" h="auto">
+                            <vertical id="DefaultExtraSettings2" visibility="gone" padding="10 8 0 0" w="*" h="auto">
                                 <linear>
                                     <text text="每隔" textColor="#000000" />
                                     <input maxLength="5" id="breakAutoCycleDuration" hint="留空即不打断" text="" textSize="14" inputType="number|none" />
@@ -134,23 +137,7 @@ ui.layout(
                                 </linear>
                                 <text text="经过设定的秒数后,长按打断官方自动周回" textColor="#000000" />
                             </vertical>
-                            <vertical id="DefaultExtraSettings3" visibility="gone" padding="0 8 0 0" w="*" h="auto">
-                                <linear>
-                                    <text text="假死检测超时" textColor="#000000" />
-                                    <input maxLength="5" id="forceStopTimeout" hint="留空即不强关重开" text="" textSize="14" inputType="number|none" />
-                                    <text text="秒" textColor="#000000" />
-                                </linear>
-                                <text text="如果停留在一个状态超过设定的秒数,就认为游戏已经假死,然后杀进程重开" textColor="#000000" />
-                            </vertical>
-                            <vertical id="DefaultExtraSettings4" visibility="gone" padding="0 8 0 0" w="*" h="auto">
-                                <linear>
-                                    <text text="无条件杀进程重开,每隔" textColor="#000000" />
-                                    <input maxLength="5" id="periodicallyKillTimeout" hint="留空即不强关重开" text="" textSize="14" inputType="number|none" />
-                                    <text text="秒一次" textColor="#000000" />
-                                </linear>
-                                <text text="有的时候游戏会发生内存泄露,内存占用持续上升直至爆炸,可能导致脚本进程也被杀死。这种情况下,设置假死检测、打断官方自动续战可能都没用,于是就不得不设置这个万不得已的选项。" textColor="#000000" />
-                            </vertical>
-                            <vertical id="DefaultExtraSettings5" visibility="gone" padding="0 8 0 0" w="*" h="auto">
+                            <vertical id="DefaultExtraSettings3" visibility="gone" padding="10 8 0 6" w="*" h="auto">
                                 <linear padding="0 0 0 0" w="*" h="auto">
                                     <text text="等待控件超时" textColor="#000000" />
                                     <input maxLength="6" margin="5 0 0 0" id="timeout" hint="5000" text="5000" textSize="14" inputType="number|none" />
@@ -158,7 +145,27 @@ ui.layout(
                                 </linear>
                                 <text text="修改“等待控件超时”并不能让脚本变快,数值太小反而可能出错。如果不是机器特别卡(这种情况也要把这个值改得更大,而不是更小)请不要改,退格可自动恢复默认(5000毫秒)" textColor="#000000" />
                             </vertical>
-                            <vertical id="DefaultExtraSettings6" visibility="gone" padding="0 8 0 6" w="*" h="auto">
+                            <vertical padding="0 8 0 0" w="*" h="auto">
+                                <Switch id="toggleDefaultCrashRestartExtraSettings" text="显示闪退自动重开设置" textColor="#666666" />
+                                <text text="[录制闪退重开选关动作]后即可在[副本周回(剧情/活动通用)]脚本启动时选择启用闪退自动重开,应对闪退或掉线后强制回首页的情况。" textColor="#000000" />
+                            </vertical>
+                            <vertical id="DefaultCrashRestartExtraSettings1" visibility="gone" padding="10 8 0 0" w="*" h="auto">
+                                <linear>
+                                    <text text="假死检测超时" textColor="#000000" />
+                                    <input maxLength="5" id="forceStopTimeout" hint="留空即不强关重开" text="" textSize="14" inputType="number|none" />
+                                    <text text="秒" textColor="#000000" />
+                                </linear>
+                                <text text="如果停留在一个状态超过设定的秒数,就认为游戏已经假死,然后杀进程重开" textColor="#000000" />
+                            </vertical>
+                            <vertical id="DefaultCrashRestartExtraSettings2" visibility="gone" padding="10 8 0 0" w="*" h="auto">
+                                <linear>
+                                    <text text="无条件杀进程重开,每隔" textColor="#000000" />
+                                    <input maxLength="5" id="periodicallyKillTimeout" hint="留空即不强关重开" text="" textSize="14" inputType="number|none" />
+                                    <text text="秒一次" textColor="#000000" />
+                                </linear>
+                                <text text="有的时候游戏会发生内存泄露,内存占用持续上升直至爆炸,可能导致脚本进程也被杀死。这种情况下,设置假死检测、打断官方自动续战可能都没用,于是就不得不设置这个万不得已的选项。" textColor="#000000" />
+                            </vertical>
+                            <vertical id="DefaultCrashRestartExtraSettings3" visibility="gone" padding="10 8 0 6" w="*" h="auto">
                                 <Switch id="rootForceStop" w="*" margin="0 3" checked="false" textColor="#000000" text="优先使用root或adb权限杀进程" />
                                 <text text="部分模拟器等环境下,没有root或adb(Shizuku)权限可能无法杀死进程。真机则一般可以把游戏先切到后台(然后一般就暂停运行了)再杀死。如果你无法获取root或adb权限,而且先切到后台再杀进程这个办法奏效,就可以关掉这个选项。" textColor="#000000" />
                             </vertical>
@@ -170,11 +177,11 @@ ui.layout(
                             <vertical padding="0 8 0 6" w="*" h="auto">
                                 <Switch id="toggleMirrorsExtraSettings" w="*" margin="0 3" checked="false" textColor="#666666" text="显示更多选项" />
                             </vertical>
-                            <vertical id="MirrorsExtraSettings1" visibility="gone" padding="0 8 0 6" w="*" h="auto">
+                            <vertical id="MirrorsExtraSettings1" visibility="gone" padding="10 8 0 6" w="*" h="auto">
                                 <Switch id="smartMirrorsPick" w="*" margin="0 3" checked="true" textColor="#000000" text="智能挑选最弱对手" />
                                 <text text="开启此项后会先找总战力低于我方六分之一的弱队,如果找不到就挨个点开队伍详情计算平均战力,从而找到最弱对手。如果碰到问题可以关闭这个选项,然后就只会挑选第3个对手" textColor="#000000" />
                             </vertical>
-                            <vertical id="MirrorsExtraSettings2" visibility="gone" padding="0 8 0 6" w="*" h="auto">
+                            <vertical id="MirrorsExtraSettings2" visibility="gone" padding="10 8 0 6" w="*" h="auto">
                                 <Switch id="useCVAutoBattle" w="*" margin="0 3" checked="true" textColor="#000000" text="在周回中使用识图自动战斗" />
                                 <text text="开启此项,可以通过截屏识图自动完成连携。关闭此项,则镜层周回使用简单无脑点第1/2/3个盘来自动完成战斗" textColor="#000000" />
                             </vertical>
@@ -186,23 +193,23 @@ ui.layout(
                             <vertical padding="0 8 0 6" w="*" h="auto">
                                 <Switch id="toggleCVAutoBattleExtraSettings" w="*" margin="0 3" checked="false" textColor="#666666" text="显示更多选项" />
                             </vertical>
-                            <vertical id="CVAutoBattleExtraSettings1" visibility="gone" padding="0 8 0 6" w="*" h="auto">
+                            <vertical id="CVAutoBattleExtraSettings1" visibility="gone" padding="10 8 0 6" w="*" h="auto">
                                 <Switch id="rootScreencap" w="*" margin="0 3" checked="false" textColor="#000000" text="使用root或adb权限截屏" />
                                 <text text="部分环境下截屏权限会在一段时间后丢失,或者出现截屏后处理数据时报错崩溃的问题。这些情况下可以开启这个选项,但开启后截图效率会下降" textColor="#000000" />
                                 <text text="注意!超级用户授权通知会遮挡屏幕、干扰截屏识图,所以务必要关掉这个通知(对模拟器来说,一般可以在系统设置里找到超级用户设置)。也可以改用不会弹出通知的Shizuku来授权" textColor="#FF0000" />
                             </vertical>
-                            <vertical id="CVAutoBattleExtraSettings2" visibility="gone" padding="0 8 0 6" w="*" h="auto">
+                            <vertical id="CVAutoBattleExtraSettings2" visibility="gone" padding="10 8 0 6" w="*" h="auto">
                                 <Switch id="CVAutoBattleDebug" w="*" margin="0 3" checked="false" textColor="#000000" text="识图自动战斗启用调试模式" />
                                 <text text="开启后,识图自动战斗将不会点击行动盘,只会在保存一些图片后结束运行,以方便排查bug" textColor="#000000" />
                             </vertical>
-                            <vertical id="CVAutoBattleExtraSettings3" visibility="gone" padding="0 8 0 6" w="*" h="auto">
+                            <vertical id="CVAutoBattleExtraSettings3" visibility="gone" padding="10 8 0 6" w="*" h="auto">
                                 <Switch id="CVAutoBattleClickAllSkills" w="*" margin="0 3" checked="true" textColor="#000000" text="使用主动技能" />
                                 <text text="开启后,从第3回合开始,会放出所有可用的主动技能。如果遇到问题可以关闭" textColor="#000000" />
                             </vertical>
                         </vertical>
                     </vertical>
                     <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
-                        <text text="备用脚本设置" textColor="#000000" padding="5" w="*" bg="#eeeeee" />
+                        <text text="副本/活动周回2(备用可选)脚本设置" textColor="#000000" padding="5" w="*" bg="#eeeeee" />
                         <vertical padding="10 6 0 6" w="*" h="auto">
                             <text text="活动周回关卡选择:" textColor="#000000" margin="0 5" />
                             <radiogroup id="battleNo" padding="10 3 0 3">
@@ -517,7 +524,7 @@ function setToggleListener(key) {
         }
     });
 }
-for (let key of ["Default", "Mirrors", "CVAutoBattle"]) {
+for (let key of ["Default", "DefaultCrashRestart", "Mirrors", "CVAutoBattle"]) {
     setToggleListener(key);
 }
 

--- a/main.js
+++ b/main.js
@@ -63,11 +63,6 @@ ui.layout(
                             <text id="exitOnServiceSettingsText2" visibility="gone" textSize="12" text="OPPO等部分品牌的手机在有悬浮窗(比如“加速球”)存在时会拒绝开启无障碍服务" textColor="#000000" />
                             <text id="exitOnServiceSettingsText3" visibility="gone" textSize="12" text="启用这个选项后，在弹出无障碍设置时，脚本会完全退出、从而关闭悬浮窗来避免触发这个问题" textColor="#000000" />
                             <text id="exitOnServiceSettingsText4" visibility="gone" textSize="12" text="与此同时请关闭其他有悬浮窗的应用(简单粗暴的方法就是清空后台)以确保无障碍服务可以顺利开启" textColor="#000000" />
-                            <Switch id="killSelf" margin="0 3" w="*" textColor="#666666" checked="false" text="错误地检测到竖屏" />
-                            <text id="killSelfText1" visibility="gone" textSize="12" text="“检测到竖屏”这个警告出现时,表示脚本因为无法获取正确的屏幕数据,而无法正确运行,比如捕获点击坐标的半透明悬浮窗本来应该完整覆盖屏幕,却只覆盖了半边屏幕" textColor="#666666" />
-                            <text id="killSelfText2" visibility="gone" textSize="12" text="启用后,脚本会在按返回键退出时杀死自己的进程" textColor="#666666" />
-                            <text id="killSelfText3" visibility="gone" textSize="12" text="注意!杀死自己的进程会带来一个副作用:无障碍服务需要更频繁地重新开启" textColor="#666666" />
-                            <text id="killSelfText4" visibility="gone" textSize="12" text="这个选项参数不会永久保存,下次启动时会重置为默认值,也就是停用" textColor="#666666" />
                         </vertical>
                     </vertical>
 
@@ -625,7 +620,6 @@ const tempParamList = [
     "drug3num",
     "drug4num",
     "apmul",
-    "killSelf",
 ];
 
 var idmap = {};
@@ -850,7 +844,6 @@ function toUpdate() {
                         app.launch(context.getPackageName())
                         toast("更新完毕")
                     })
-                    floatUI.isUpgrading = true; //避免把自己的后台杀了
                     engines.stopAll()
                 } else {
                     toast("脚本获取失败！这可能是您的网络原因造成的，建议您检查网络后再重新运行软件吧\nHTTP状态码:" + main_script.statusMessage, "," + float_script.statusMessage);

--- a/main.js
+++ b/main.js
@@ -6,6 +6,10 @@ importClass(com.stardust.autojs.project.ProjectConfig)
 importClass(com.stardust.autojs.core.ui.inflater.util.Ids)
 importClass(Packages.androidx.core.graphics.drawable.DrawableCompat)
 importClass(Packages.androidx.appcompat.content.res.AppCompatResources)
+importClass(android.webkit.WebView)
+importClass(android.webkit.WebChromeClient)
+importClass(android.webkit.WebResourceResponse)
+importClass(android.webkit.WebViewClient)
 
 var Name = "AutoBattle";
 var version = "5.3.0";
@@ -28,238 +32,6 @@ function logException(e) {
 }
 
 var floatUI = require('floatUI.js');
-
-ui.statusBarColor("#FF4FB3FF")
-ui.layout(
-    <relative id="container">
-        <appbar id="appbar" w="*">
-            <toolbar id="toolbar" bg="#ff4fb3ff" title="{{appName}}" />
-        </appbar>
-        <vertical id="running_stats" visibility="gone" w="fill_parent" h="fill_parent" layout_below="appbar" gravity="center_horizontal">
-            <text id="running_stats_title" text="脚本运行中" textColor="#00D000" textSize="20" w="wrap_content" h="wrap_content"/>
-            <text id="running_stats_status_text" marginLeft="5" layout_gravity="center_vertical" text="" w="wrap_content" h="wrap_content"/>
-            <text id="running_stats_params_text" marginLeft="5" layout_gravity="center_vertical" text="" w="wrap_content" h="wrap_content"/>
-        </vertical>
-        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout id="swipe" layout_below="appbar">
-            <ScrollView id="content">
-                <vertical gravity="center" layout_weight="1">
-                    <vertical id="autojs_ver_vertical" visibility="gone" margin="0 5" padding="10 6 0 6" bg="#ffffff" w="*" h="auto" elevation="1dp">
-                        <text id="autojs_ver_text" text="AutoJS Pro 引擎版本过低" textColor="#FFCC00" textSize="16" w="wrap_content" h="wrap_content"/>
-                    </vertical>
-
-                    <vertical id="task_paused_vertical" visibility="gone" margin="0 5" padding="10 6 0 6" bg="#ffffff" w="*" h="auto" elevation="1dp">
-                        <text id="task_paused_title" text="脚本已暂停" textColor="#FFCC00" textSize="20" w="wrap_content" h="wrap_content"/>
-                        <button id="task_paused_button" text="返回游戏并继续运行脚本" textColor="#000000" textSize="16" w="wrap_content" h="wrap_content"/>
-                    </vertical>
-
-                    <vertical margin="0 5" padding="10 6 0 6" bg="#ffffff" w="*" h="auto" elevation="1dp">
-                        <Switch id="autoService" margin="0 3" w="*" checked="{{auto.service != null}}" textColor="#666666" text="无障碍服务" />
-                        <Switch id="foreground" margin="0 3" w="*" textColor="#000000" text="前台服务（常被鲨进程可以开启，按需）" />
-                        <Switch id="stopOnVolUp" margin="0 3" w="*" textColor="#000000" text="按音量上键停止全部脚本" />
-                        <Switch id="showExperimentalFixes" margin="0 3" w="*" checked="false" textColor="#666666" text="显示实验性问题修正选项" />
-                        <vertical id="experimentalFixes" visibility="gone" margin="5 3" w="*">
-                            <Switch id="exitOnServiceSettings" margin="0 3" w="*" checked="false" textColor="#000000" text="OPPO手机拒绝开启无障碍服务" />
-                            <text id="exitOnServiceSettingsText1" visibility="gone" textSize="12" text="如果不是OPPO则不建议打开这个选项" textColor="#000000" />
-                            <text id="exitOnServiceSettingsText2" visibility="gone" textSize="12" text="OPPO等部分品牌的手机在有悬浮窗(比如“加速球”)存在时会拒绝开启无障碍服务" textColor="#000000" />
-                            <text id="exitOnServiceSettingsText3" visibility="gone" textSize="12" text="启用这个选项后，在弹出无障碍设置时，脚本会完全退出、从而关闭悬浮窗来避免触发这个问题" textColor="#000000" />
-                            <text id="exitOnServiceSettingsText4" visibility="gone" textSize="12" text="与此同时请关闭其他有悬浮窗的应用(简单粗暴的方法就是清空后台)以确保无障碍服务可以顺利开启" textColor="#000000" />
-                        </vertical>
-                    </vertical>
-
-                    <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
-                        <text text="全局设置" textColor="#000000" padding="5" w="*" bg="#eeeeee" />
-                        <vertical padding="10 6 0 6" w="*" h="auto">
-                            <linear margin="0 3">
-                                <text text="默认执行脚本" layout_weight="1" layout_gravity="center_vertical" textColor="#000000" />
-                                <spinner id="default" h="auto" gravity="right" textSize="14" textColor="#000000" entries="{{floatUI.scripts.map(x=>x.name).join('|')}}" />
-                            </linear>
-                            <text text="回复药使用选择:" margin="0 5" />
-                            <vertical padding="10 3 0 3" w="*" h="auto">
-                                <linear>
-                                    <checkbox id="drug1" text="AP回复药50(绿药)" layout_weight="1" textColor="#666666" />
-                                    <text text="个数限制" textColor="#666666" />
-                                    <input maxLength="3" id="drug1num" hint="留空即无限制" text="0" textSize="14" inputType="number|none" />
-                                </linear>
-                                <linear>
-                                    <checkbox id="drug2" text="AP回复药全(红药)" layout_weight="1" textColor="#666666" />
-                                    <text text="个数限制" textColor="#666666" />
-                                    <input maxLength="3" id="drug2num" hint="留空即无限制" text="0" textSize="14" inputType="number|none" />
-                                </linear>
-                                <linear>
-                                    <checkbox id="drug3" text="魔法石" layout_weight="1" textColor="#666666" />
-                                    <text text="碎钻个数" textColor="#666666" />
-                                    <text text="(不是次数!)" textColor="#ff00ff" />
-                                    <input maxLength="3" id="drug3num" hint="留空即无限制" text="0" textSize="14" inputType="number|none" />
-                                </linear>
-                                <linear>
-                                    <checkbox id="drug4" text="BP回复药(镜层)" layout_weight="1" textColor="#666666" />
-                                    <text text="个数限制" textColor="#666666" />
-                                    <input maxLength="3" id="drug4num" hint="留空即无限制" text="0" textSize="14" inputType="number|none" />
-                                </linear>
-                                <text text="注意:回复药开关状态和个数限制不会永久保存,在脚本完全退出后,这些设置会被重置!" textColor="#666666" />
-                            </vertical>
-                            <Switch id="justNPC" w="*" margin="0 5" checked="false" textColor="#000000" text="只使用NPC(不选则先互关好友,后NPC)" />
-                            <Switch id="autoReconnect" w="*" margin="0 3" checked="false" textColor="#000000" text="防断线模式(尽可能自动点击断线重连按钮)" />
-                            <vertical padding="0 3 0 0" w="*" h="auto">
-                                <text textColor="#000000" text="防断线模式仅限于在战斗中自动点击断线重连按钮,无法应对强制回首页的情况。闪退自动重开可以应对强制回首页。" />
-                            </vertical>
-                        </vertical>
-                    </vertical>
-                    <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
-                        <text text="默认脚本设置" textColor="#000000" padding="5" w="*" bg="#eeeeee" />
-                        <vertical padding="10 6 0 6" w="*" h="auto">
-                            <Switch id="useAuto" w="*" margin="0 3" checked="true" textColor="#000000" text="优先使用官方自动续战" />
-                            <vertical padding="0 8 0 0" w="*" h="auto">
-                                <linear padding="0 0 0 0" w="*" h="auto">
-                                    <text text="嗑药至AP上限" textColor="#666666" />
-                                    <input maxLength="1" margin="5 0 0 0" id="apmul" hint="可选值0-4,留空视为0" text="" textSize="14" inputType="number|none" />
-                                    <text text="倍以上" textColor="#666666" />
-                                </linear>
-                                <text text="注意:嗑药至AP上限倍数不会永久保存,脚本完全退出后会被重置!" textColor="#666666" />
-                            </vertical>
-                            <vertical padding="0 8 0 0" w="*" h="auto">
-                                <Switch id="toggleDefaultExtraSettings" w="*" margin="0 3" checked="false" textColor="#666666" text="显示更多选项" />
-                            </vertical>
-                            <vertical id="DefaultExtraSettings1" visibility="gone" padding="10 8 0 0" w="*" h="auto">
-                                <Switch id="autoFollow" w="*" margin="0 3" checked="true" textColor="#000000" text="自动关注路人" />
-                                <text text="启用后如果助战选到了路人,会在结算时关注他。停用这个选项则不会关注路人,在结算时如果出现询问关注的弹窗,会直接关闭。" textColor="#000000" />
-                            </vertical>
-                            <vertical id="DefaultExtraSettings2" visibility="gone" padding="10 8 0 0" w="*" h="auto">
-                                <linear>
-                                    <text text="每隔" textColor="#000000" />
-                                    <input maxLength="5" id="breakAutoCycleDuration" hint="留空即不打断" text="" textSize="14" inputType="number|none" />
-                                    <text text="秒打断官方自动续战" textColor="#000000" />
-                                </linear>
-                                <text text="经过设定的秒数后,长按打断官方自动周回" textColor="#000000" />
-                            </vertical>
-                            <vertical id="DefaultExtraSettings3" visibility="gone" padding="10 8 0 6" w="*" h="auto">
-                                <linear padding="0 0 0 0" w="*" h="auto">
-                                    <text text="等待控件超时" textColor="#000000" />
-                                    <input maxLength="6" margin="5 0 0 0" id="timeout" hint="5000" text="5000" textSize="14" inputType="number|none" />
-                                    <text text="毫秒" textColor="#000000" />
-                                </linear>
-                                <text text="修改“等待控件超时”并不能让脚本变快,数值太小反而可能出错。如果不是机器特别卡(这种情况也要把这个值改得更大,而不是更小)请不要改,退格可自动恢复默认(5000毫秒)" textColor="#000000" />
-                            </vertical>
-                            <vertical padding="0 8 0 0" w="*" h="auto">
-                                <Switch id="toggleDefaultCrashRestartExtraSettings" text="显示闪退自动重开设置" textColor="#666666" />
-                                <text text="[录制闪退重开选关动作]后即可在[副本周回(剧情/活动通用)]脚本启动时选择启用闪退自动重开,应对闪退或掉线后强制回首页的情况。" textColor="#000000" />
-                            </vertical>
-                            <vertical id="DefaultCrashRestartExtraSettings1" visibility="gone" padding="10 8 0 0" w="*" h="auto">
-                                <linear>
-                                    <text text="假死检测超时" textColor="#000000" />
-                                    <input maxLength="5" id="forceStopTimeout" hint="留空即不强关重开" text="" textSize="14" inputType="number|none" />
-                                    <text text="秒" textColor="#000000" />
-                                </linear>
-                                <text text="如果停留在一个状态超过设定的秒数,就认为游戏已经假死,然后杀进程重开" textColor="#000000" />
-                            </vertical>
-                            <vertical id="DefaultCrashRestartExtraSettings2" visibility="gone" padding="10 8 0 0" w="*" h="auto">
-                                <linear>
-                                    <text text="无条件杀进程重开,每隔" textColor="#000000" />
-                                    <input maxLength="5" id="periodicallyKillTimeout" hint="留空即不强关重开" text="" textSize="14" inputType="number|none" />
-                                    <text text="秒一次" textColor="#000000" />
-                                </linear>
-                                <text text="有的时候游戏会发生内存泄露,内存占用持续上升直至爆炸,可能导致脚本进程也被杀死。这种情况下,设置假死检测、打断官方自动续战可能都没用,于是就不得不设置这个万不得已的选项。" textColor="#000000" />
-                            </vertical>
-                            <vertical id="DefaultCrashRestartExtraSettings3" visibility="gone" padding="10 8 0 6" w="*" h="auto">
-                                <Switch id="rootForceStop" w="*" margin="0 3" checked="false" textColor="#000000" text="优先使用root或adb权限杀进程" />
-                                <text text="部分模拟器等环境下,没有root或adb(Shizuku)权限可能无法杀死进程。真机则一般可以把游戏先切到后台(然后一般就暂停运行了)再杀死。如果你无法获取root或adb权限,而且先切到后台再杀进程这个办法奏效,就可以关掉这个选项。" textColor="#000000" />
-                            </vertical>
-                        </vertical>
-                    </vertical>
-                    <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
-                        <text text="镜层周回脚本设置" textColor="#000000" padding="5" w="*" bg="#eeeeee" />
-                        <vertical padding="10 6 0 6" w="*" h="auto">
-                            <vertical padding="0 8 0 6" w="*" h="auto">
-                                <Switch id="toggleMirrorsExtraSettings" w="*" margin="0 3" checked="false" textColor="#666666" text="显示更多选项" />
-                            </vertical>
-                            <vertical id="MirrorsExtraSettings1" visibility="gone" padding="10 8 0 6" w="*" h="auto">
-                                <Switch id="smartMirrorsPick" w="*" margin="0 3" checked="true" textColor="#000000" text="智能挑选最弱对手" />
-                                <text text="开启此项后会先找总战力低于我方六分之一的弱队,如果找不到就挨个点开队伍详情计算平均战力,从而找到最弱对手。如果碰到问题可以关闭这个选项,然后就只会挑选第3个对手" textColor="#000000" />
-                            </vertical>
-                            <vertical id="MirrorsExtraSettings2" visibility="gone" padding="10 8 0 6" w="*" h="auto">
-                                <Switch id="useCVAutoBattle" w="*" margin="0 3" checked="true" textColor="#000000" text="在周回中使用识图自动战斗" />
-                                <text text="开启此项,可以通过截屏识图自动完成连携。关闭此项,则镜层周回使用简单无脑点第1/2/3个盘来自动完成战斗" textColor="#000000" />
-                            </vertical>
-                        </vertical>
-                    </vertical>
-                    <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
-                        <text text="识图自动战斗(自动点击行动盘(识图,连携))脚本设置" textColor="#000000" padding="5" w="*" bg="#eeeeee" />
-                        <vertical padding="10 6 0 6" w="*" h="auto">
-                            <vertical padding="0 8 0 6" w="*" h="auto">
-                                <Switch id="toggleCVAutoBattleExtraSettings" w="*" margin="0 3" checked="false" textColor="#666666" text="显示更多选项" />
-                            </vertical>
-                            <vertical id="CVAutoBattleExtraSettings1" visibility="gone" padding="10 8 0 6" w="*" h="auto">
-                                <Switch id="rootScreencap" w="*" margin="0 3" checked="false" textColor="#000000" text="使用root或adb权限截屏" />
-                                <text text="部分环境下截屏权限会在一段时间后丢失,或者出现截屏后处理数据时报错崩溃的问题。这些情况下可以开启这个选项,但开启后截图效率会下降" textColor="#000000" />
-                                <text text="注意!超级用户授权通知会遮挡屏幕、干扰截屏识图,所以务必要关掉这个通知(对模拟器来说,一般可以在系统设置里找到超级用户设置)。也可以改用不会弹出通知的Shizuku来授权" textColor="#FF0000" />
-                            </vertical>
-                            <vertical id="CVAutoBattleExtraSettings2" visibility="gone" padding="10 8 0 6" w="*" h="auto">
-                                <Switch id="CVAutoBattleDebug" w="*" margin="0 3" checked="false" textColor="#000000" text="识图自动战斗启用调试模式" />
-                                <text text="开启后,识图自动战斗将不会点击行动盘,只会在保存一些图片后结束运行,以方便排查bug" textColor="#000000" />
-                            </vertical>
-                            <vertical id="CVAutoBattleExtraSettings3" visibility="gone" padding="10 8 0 6" w="*" h="auto">
-                                <Switch id="CVAutoBattleClickAllSkills" w="*" margin="0 3" checked="true" textColor="#000000" text="使用主动技能" />
-                                <text text="开启后,从第3回合开始,会放出所有可用的主动技能。如果遇到问题可以关闭" textColor="#000000" />
-                            </vertical>
-                        </vertical>
-                    </vertical>
-                    <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
-                        <text text="副本/活动周回2(备用可选)脚本设置" textColor="#000000" padding="5" w="*" bg="#eeeeee" />
-                        <vertical padding="10 6 0 6" w="*" h="auto">
-                            <text text="活动周回关卡选择:" textColor="#000000" margin="0 5" />
-                            <radiogroup id="battleNo" padding="10 3 0 3">
-                                <radio id="cb1" text="初级" />
-                                <radio id="cb2" text="中级" />
-                                <radio id="cb3" text="高级" checked="true" />
-                            </radiogroup>
-                            <linear margin="0 3">
-                                <text text="助战x，y坐标自定义:" textColor="#000000" layout_gravity="center_vertical" />
-                                <input maxLength="4" id="helpx" text="" hint="横坐标" textSize="14" inputType="number|none" />
-                                <input maxLength="4" id="helpy" text="" hint="纵坐标" textSize="14" inputType="number|none" />
-                            </linear>
-                        </vertical>
-                    </vertical>
-                    <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
-                        <text text="关于" textColor="#000000" padding="5" w="*" bg="#eeeeee" />
-                        <linear padding="10 6" bg="#ffffff">
-                            <text id="versionMsg" layout_weight="1" w="*" gravity="center" color="#666666" text="尝试获取最新版本信息" />
-                        </linear>
-                        <linear padding="10 6" bg="#ffffff">
-                            <text id="" layout_weight="1" color="#666666" text="版权声明，本app仅供娱乐学习使用，且永久免费，不可进行出售盈利。作者bilibili 虹之宝玉  群号：453053507" />
-                        </linear>
-                    </vertical>
-                </vertical>
-            </ScrollView>
-        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
-    </relative>
-);
-
-ui.emitter.on("create_options_menu", menu => {
-    //在菜单内显示图标
-    let menuClass = menu.getClass();
-    if(menuClass.getSimpleName().equals("MenuBuilder")){
-        try {
-            let m = menuClass.getDeclaredMethod("setOptionalIconsVisible", java.lang.Boolean.TYPE);
-            m.setAccessible(true);
-            m.invoke(menu, true);
-        } catch(e){
-            log(e);
-        }
-    }
-    //SHOW_AS_ACTION_IF_ROOM在竖屏下不会显示文字,所以不设置
-    let item = menu.add("报告问题");
-    item.setIcon(getTintDrawable("ic_report_black_48dp", colors.WHITE));
-    item.setShowAsAction(MenuItem.SHOW_AS_ACTION_WITH_TEXT);
-    item = menu.add("查看日志");
-    item.setIcon(getTintDrawable("ic_assignment_black_48dp", colors.WHITE));
-    item.setShowAsAction(MenuItem.SHOW_AS_ACTION_WITH_TEXT);
-    item = menu.add("魔纪百科");
-    item.setIcon(getTintDrawable("ic_book_black_48dp", colors.WHITE));
-    item.setShowAsAction(MenuItem.SHOW_AS_ACTION_WITH_TEXT);
-    item = menu.add("模拟抽卡");
-    item.setIcon(getTintDrawable("ic_store_black_48dp", colors.WHITE));
-    item.setShowAsAction(MenuItem.SHOW_AS_ACTION_WITH_TEXT);
-});
 
 function setFollowRedirects(value) {
     let newokhttp = new Packages.okhttp3.OkHttpClient.Builder().followRedirects(value);
@@ -411,449 +183,776 @@ function reportBug() {
     }
 }
 
-ui.emitter.on("options_item_selected", (e, item) => {
-    switch (item.getTitle()) {
-        case "报告问题":
-            if (reportTask && reportTask.isAlive()) {
-                toastLog("已经在上传了,请稍后再试");
-            } else {
-                reportTask = threads.start(reportBug);
-            }
-            break;
-        case "查看日志":
-            app.startActivity("console")
-            break;
-        case "魔纪百科":
-            app.openUrl("https://magireco.moe/");
-            break;
-        case "模拟抽卡":
-            app.openUrl("https://rika.ren/~kuro/workspace/playground/");
-            break;
-    }
-    e.consumed = true;
-});
+var isDevMode = false;//TODO 以后用上Webpack了就改成根据NODE_ENV来判断
 
-activity.setSupportActionBar(ui.toolbar);
-
-function getTintDrawable(name, tint) {
-    var id = context.getResources().getIdentifier(name, "drawable", context.getPackageName());
-    var raw = AppCompatResources.getDrawable(context, id);
-    var wrapped = DrawableCompat.wrap(raw);
-    DrawableCompat.setTint(wrapped, tint);
-    return wrapped
+var useLegacySettingsUI = false;
+if (files.isFile(files.join(files.cwd(), "use_legacy_settings_ui"))) {
+    useLegacySettingsUI = true;
 }
 
-//检测AutoJS引擎版本
-
-//经测试发现app.autojs.versionName不能用
-//以下数值通过实际运行一遍代码取得，取自Pro 8.8.13-0
-const lowestVersionCode = 8081200;
-
-function detectAutoJSVersion() {
-    ui.run(function() {
-        let currentVersionCode = NaN;
-        try {
-            currentVersionCode = parseInt(app.autojs.versionCode);
-        } catch (e) {
-            currentVersionCode = NaN;
-        }
-        if (isNaN(currentVersionCode)) {
-            ui.autojs_ver_text.setText("无法检测 AutoJS Pro 引擎版本\n继续使用可能碰到问题\n推荐下载最新apk安装包进行更新");
-            ui.autojs_ver_vertical.setVisibility(View.VISIBLE);
+function switchSettingsUI(mode) {
+    let path = files.join(files.cwd(), "use_legacy_settings_ui");
+    switch (mode) {
+        case "legacy":
+            toastLog("切换到旧版设置界面");
+            files.ensureDir(path);
+            files.create(path);
+            break;
+        case "webview":
+            toastLog("切换到新版设置界面");
+            files.remove(path);
+            break;
+        default:
+            toastLog("不知道要切换到哪种设置界面");
             return;
+    }
+    events.on("exit", function () {
+        app.launch(context.getPackageName());
+    });
+    engines.stopAll();
+}
+
+if (!useLegacySettingsUI) {
+    //使用新版UI
+    ui.layout(
+        <vertical h="auto" w="*">
+            <webview id="webview" w="auto" h="auto"/>
+        </vertical>
+    );
+
+    //正式发布
+    let path = "/autoWebview/dist/index.html"
+    let releaseUrlBase = "https://cdn.jsdelivr.net/gh/icegreentee/magireco_autoBattle@latest";
+    let releaseUrl = releaseUrlBase+path;
+
+    //开发环境，可以用adb reverse tcp:8080 tcp:8080来映射端口到npm run serve启动的HTTP服务器
+    let debugUrlBase = "http://127.0.0.1:8080";
+    let debugUrl = debugUrlBase+"/index.html";
+
+    //优先使用本地URL，文件不存在时使用在线URL
+    let onlineUrl = isDevMode ? debugUrl : releaseUrl;
+    let fileUrl = files.join(files.cwd(), path);
+    fileUrl = "file://"+fileUrl;
+    let url = files.isFile(path) ? fileUrl : onlineUrl;
+    ui.webview.loadUrl(url);
+
+    //借用prompt处理Web端主动发起的对AutoJS端的通信
+    //参考：https://www.jianshu.com/p/94277cb8f835
+    function handleWebViewCallAJ(fnName, paramString) {
+        switch (fnName) {
+            case "switchSettingsUI":
+                try {
+                    let params = JSON.parse(paramString);
+                    if (params.length > 0)
+                        switchSettingsUI(params[0]);
+                } catch (e) {logException(e);}
+                break;
+            default:
+                toastLog("未知的callAJ命令:\n["+fnName+"]");
         }
-        if (currentVersionCode < lowestVersionCode) {
-            ui.autojs_ver_text.setText("AutoJS Pro 引擎版本过低\n当前版本versionCode=["+currentVersionCode+"]\n最低要求versionCode=["+lowestVersionCode+"]\n继续使用可能碰到问题\n推荐下载最新apk安装包进行更新");
-            ui.autojs_ver_vertical.setVisibility(View.VISIBLE);
-            return;
+    }
+    let webViewSettings = ui.webview.getSettings();
+    webViewSettings.setAllowFileAccessFromFileURLs(false);
+    webViewSettings.setAllowUniversalAccessFromFileURLs(false);
+    webViewSettings.setSupportZoom(false);
+    webViewSettings.setJavaScriptEnabled(true);
+    var webcc = new JavaAdapter(WebChromeClient, {
+        onJsPrompt: function (view, url, message, defaultValue, jsPromptResult) {
+            handleWebViewCallAJ(message, defaultValue);
+            jsPromptResult.confirm();//这段代码是必要的，否则会弹出prompt，阻塞界面。
+            return true;
         }
     });
-}
-detectAutoJSVersion();
+    ui.webview.setWebChromeClient(webcc)
+} else {
+    //使用旧版UI
+    ui.statusBarColor("#FF4FB3FF")
+    ui.layout(
+        <relative id="container">
+            <appbar id="appbar" w="*">
+                <toolbar id="toolbar" bg="#ff4fb3ff" title="{{appName}}" />
+            </appbar>
+            <vertical id="running_stats" visibility="gone" w="fill_parent" h="fill_parent" layout_below="appbar" gravity="center_horizontal">
+                <text id="running_stats_title" text="脚本运行中" textColor="#00D000" textSize="20" w="wrap_content" h="wrap_content"/>
+                <text id="running_stats_status_text" marginLeft="5" layout_gravity="center_vertical" text="" w="wrap_content" h="wrap_content"/>
+                <text id="running_stats_params_text" marginLeft="5" layout_gravity="center_vertical" text="" w="wrap_content" h="wrap_content"/>
+            </vertical>
+            <androidx.swiperefreshlayout.widget.SwipeRefreshLayout id="swipe" layout_below="appbar">
+                <ScrollView id="content">
+                    <vertical gravity="center" layout_weight="1">
+                        <vertical id="autojs_ver_vertical" visibility="gone" margin="0 5" padding="10 6 0 6" bg="#ffffff" w="*" h="auto" elevation="1dp">
+                            <text id="autojs_ver_text" text="AutoJS Pro 引擎版本过低" textColor="#FFCC00" textSize="16" w="wrap_content" h="wrap_content"/>
+                        </vertical>
 
-//无障碍开关监控
-ui.autoService.setOnCheckedChangeListener(function (widget, checked) {
-    if (checked && !auto.service) {
-        app.startActivity({
-            action: "android.settings.ACCESSIBILITY_SETTINGS"
-        });
-        //部分品牌的手机在有悬浮窗的情况下拒绝开启无障碍服务（目前只发现OPPO是这样）
-        //为了关闭悬浮窗，最简单的办法就是退出脚本
-        ui.run(function () {
-            if (ui["exitOnServiceSettings"].isChecked()) exit();
+                        <vertical id="task_paused_vertical" visibility="gone" margin="0 5" padding="10 6 0 6" bg="#ffffff" w="*" h="auto" elevation="1dp">
+                            <text id="task_paused_title" text="脚本已暂停" textColor="#FFCC00" textSize="20" w="wrap_content" h="wrap_content"/>
+                            <button id="task_paused_button" text="返回游戏并继续运行脚本" textColor="#000000" textSize="16" w="wrap_content" h="wrap_content"/>
+                        </vertical>
+
+                        <vertical margin="0 5" padding="10 6 0 6" bg="#ffffff" w="*" h="auto" elevation="1dp">
+                            <button id="switch_ui_button" text="切换到新版设置界面" textColor="#000000" textSize="16" w="wrap_content" h="wrap_content"/>
+                        </vertical>
+
+                        <vertical margin="0 5" padding="10 6 0 6" bg="#ffffff" w="*" h="auto" elevation="1dp">
+                            <Switch id="autoService" margin="0 3" w="*" checked="{{auto.service != null}}" textColor="#666666" text="无障碍服务" />
+                            <Switch id="foreground" margin="0 3" w="*" textColor="#000000" text="前台服务（常被鲨进程可以开启，按需）" />
+                            <Switch id="stopOnVolUp" margin="0 3" w="*" textColor="#000000" text="按音量上键停止全部脚本" />
+                            <Switch id="showExperimentalFixes" margin="0 3" w="*" checked="false" textColor="#666666" text="显示实验性问题修正选项" />
+                            <vertical id="experimentalFixes" visibility="gone" margin="5 3" w="*">
+                                <Switch id="exitOnServiceSettings" margin="0 3" w="*" checked="false" textColor="#000000" text="OPPO手机拒绝开启无障碍服务" />
+                                <text id="exitOnServiceSettingsText1" visibility="gone" textSize="12" text="如果不是OPPO则不建议打开这个选项" textColor="#000000" />
+                                <text id="exitOnServiceSettingsText2" visibility="gone" textSize="12" text="OPPO等部分品牌的手机在有悬浮窗(比如“加速球”)存在时会拒绝开启无障碍服务" textColor="#000000" />
+                                <text id="exitOnServiceSettingsText3" visibility="gone" textSize="12" text="启用这个选项后，在弹出无障碍设置时，脚本会完全退出、从而关闭悬浮窗来避免触发这个问题" textColor="#000000" />
+                                <text id="exitOnServiceSettingsText4" visibility="gone" textSize="12" text="与此同时请关闭其他有悬浮窗的应用(简单粗暴的方法就是清空后台)以确保无障碍服务可以顺利开启" textColor="#000000" />
+                            </vertical>
+                        </vertical>
+
+                        <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
+                            <text text="全局设置" textColor="#000000" padding="5" w="*" bg="#eeeeee" />
+                            <vertical padding="10 6 0 6" w="*" h="auto">
+                                <linear margin="0 3">
+                                    <text text="默认执行脚本" layout_weight="1" layout_gravity="center_vertical" textColor="#000000" />
+                                    <spinner id="default" h="auto" gravity="right" textSize="14" textColor="#000000" entries="{{floatUI.scripts.map(x=>x.name).join('|')}}" />
+                                </linear>
+                                <text text="回复药使用选择:" margin="0 5" />
+                                <vertical padding="10 3 0 3" w="*" h="auto">
+                                    <linear>
+                                        <checkbox id="drug1" text="AP回复药50(绿药)" layout_weight="1" textColor="#666666" />
+                                        <text text="个数限制" textColor="#666666" />
+                                        <input maxLength="3" id="drug1num" hint="留空即无限制" text="0" textSize="14" inputType="number|none" />
+                                    </linear>
+                                    <linear>
+                                        <checkbox id="drug2" text="AP回复药全(红药)" layout_weight="1" textColor="#666666" />
+                                        <text text="个数限制" textColor="#666666" />
+                                        <input maxLength="3" id="drug2num" hint="留空即无限制" text="0" textSize="14" inputType="number|none" />
+                                    </linear>
+                                    <linear>
+                                        <checkbox id="drug3" text="魔法石" layout_weight="1" textColor="#666666" />
+                                        <text text="碎钻个数" textColor="#666666" />
+                                        <text text="(不是次数!)" textColor="#ff00ff" />
+                                        <input maxLength="3" id="drug3num" hint="留空即无限制" text="0" textSize="14" inputType="number|none" />
+                                    </linear>
+                                    <linear>
+                                        <checkbox id="drug4" text="BP回复药(镜层)" layout_weight="1" textColor="#666666" />
+                                        <text text="个数限制" textColor="#666666" />
+                                        <input maxLength="3" id="drug4num" hint="留空即无限制" text="0" textSize="14" inputType="number|none" />
+                                    </linear>
+                                    <text text="注意:回复药开关状态和个数限制不会永久保存,在脚本完全退出后,这些设置会被重置!" textColor="#666666" />
+                                </vertical>
+                                <Switch id="justNPC" w="*" margin="0 5" checked="false" textColor="#000000" text="只使用NPC(不选则先互关好友,后NPC)" />
+                                <Switch id="autoReconnect" w="*" margin="0 3" checked="false" textColor="#000000" text="防断线模式(尽可能自动点击断线重连按钮)" />
+                                <vertical padding="0 3 0 0" w="*" h="auto">
+                                    <text textColor="#000000" text="防断线模式仅限于在战斗中自动点击断线重连按钮,无法应对强制回首页的情况。闪退自动重开可以应对强制回首页。" />
+                                </vertical>
+                            </vertical>
+                        </vertical>
+                        <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
+                            <text text="默认脚本设置" textColor="#000000" padding="5" w="*" bg="#eeeeee" />
+                            <vertical padding="10 6 0 6" w="*" h="auto">
+                                <Switch id="useAuto" w="*" margin="0 3" checked="true" textColor="#000000" text="优先使用官方自动续战" />
+                                <vertical padding="0 8 0 0" w="*" h="auto">
+                                    <linear padding="0 0 0 0" w="*" h="auto">
+                                        <text text="嗑药至AP上限" textColor="#666666" />
+                                        <input maxLength="1" margin="5 0 0 0" id="apmul" hint="可选值0-4,留空视为0" text="" textSize="14" inputType="number|none" />
+                                        <text text="倍以上" textColor="#666666" />
+                                    </linear>
+                                    <text text="注意:嗑药至AP上限倍数不会永久保存,脚本完全退出后会被重置!" textColor="#666666" />
+                                </vertical>
+                                <vertical padding="0 8 0 0" w="*" h="auto">
+                                    <Switch id="toggleDefaultExtraSettings" w="*" margin="0 3" checked="false" textColor="#666666" text="显示更多选项" />
+                                </vertical>
+                                <vertical id="DefaultExtraSettings1" visibility="gone" padding="10 8 0 0" w="*" h="auto">
+                                    <Switch id="autoFollow" w="*" margin="0 3" checked="true" textColor="#000000" text="自动关注路人" />
+                                    <text text="启用后如果助战选到了路人,会在结算时关注他。停用这个选项则不会关注路人,在结算时如果出现询问关注的弹窗,会直接关闭。" textColor="#000000" />
+                                </vertical>
+                                <vertical id="DefaultExtraSettings2" visibility="gone" padding="10 8 0 0" w="*" h="auto">
+                                    <linear>
+                                        <text text="每隔" textColor="#000000" />
+                                        <input maxLength="5" id="breakAutoCycleDuration" hint="留空即不打断" text="" textSize="14" inputType="number|none" />
+                                        <text text="秒打断官方自动续战" textColor="#000000" />
+                                    </linear>
+                                    <text text="经过设定的秒数后,长按打断官方自动周回" textColor="#000000" />
+                                </vertical>
+                                <vertical id="DefaultExtraSettings3" visibility="gone" padding="10 8 0 6" w="*" h="auto">
+                                    <linear padding="0 0 0 0" w="*" h="auto">
+                                        <text text="等待控件超时" textColor="#000000" />
+                                        <input maxLength="6" margin="5 0 0 0" id="timeout" hint="5000" text="5000" textSize="14" inputType="number|none" />
+                                        <text text="毫秒" textColor="#000000" />
+                                    </linear>
+                                    <text text="修改“等待控件超时”并不能让脚本变快,数值太小反而可能出错。如果不是机器特别卡(这种情况也要把这个值改得更大,而不是更小)请不要改,退格可自动恢复默认(5000毫秒)" textColor="#000000" />
+                                </vertical>
+                                <vertical padding="0 8 0 0" w="*" h="auto">
+                                    <Switch id="toggleDefaultCrashRestartExtraSettings" text="显示闪退自动重开设置" textColor="#666666" />
+                                    <text text="[录制闪退重开选关动作]后即可在[副本周回(剧情/活动通用)]脚本启动时选择启用闪退自动重开,应对闪退或掉线后强制回首页的情况。" textColor="#000000" />
+                                </vertical>
+                                <vertical id="DefaultCrashRestartExtraSettings1" visibility="gone" padding="10 8 0 0" w="*" h="auto">
+                                    <linear>
+                                        <text text="假死检测超时" textColor="#000000" />
+                                        <input maxLength="5" id="forceStopTimeout" hint="留空即不强关重开" text="" textSize="14" inputType="number|none" />
+                                        <text text="秒" textColor="#000000" />
+                                    </linear>
+                                    <text text="如果停留在一个状态超过设定的秒数,就认为游戏已经假死,然后杀进程重开" textColor="#000000" />
+                                </vertical>
+                                <vertical id="DefaultCrashRestartExtraSettings2" visibility="gone" padding="10 8 0 0" w="*" h="auto">
+                                    <linear>
+                                        <text text="无条件杀进程重开,每隔" textColor="#000000" />
+                                        <input maxLength="5" id="periodicallyKillTimeout" hint="留空即不强关重开" text="" textSize="14" inputType="number|none" />
+                                        <text text="秒一次" textColor="#000000" />
+                                    </linear>
+                                    <text text="有的时候游戏会发生内存泄露,内存占用持续上升直至爆炸,可能导致脚本进程也被杀死。这种情况下,设置假死检测、打断官方自动续战可能都没用,于是就不得不设置这个万不得已的选项。" textColor="#000000" />
+                                </vertical>
+                                <vertical id="DefaultCrashRestartExtraSettings3" visibility="gone" padding="10 8 0 6" w="*" h="auto">
+                                    <Switch id="rootForceStop" w="*" margin="0 3" checked="false" textColor="#000000" text="优先使用root或adb权限杀进程" />
+                                    <text text="部分模拟器等环境下,没有root或adb(Shizuku)权限可能无法杀死进程。真机则一般可以把游戏先切到后台(然后一般就暂停运行了)再杀死。如果你无法获取root或adb权限,而且先切到后台再杀进程这个办法奏效,就可以关掉这个选项。" textColor="#000000" />
+                                </vertical>
+                            </vertical>
+                        </vertical>
+                        <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
+                            <text text="镜层周回脚本设置" textColor="#000000" padding="5" w="*" bg="#eeeeee" />
+                            <vertical padding="10 6 0 6" w="*" h="auto">
+                                <vertical padding="0 8 0 6" w="*" h="auto">
+                                    <Switch id="toggleMirrorsExtraSettings" w="*" margin="0 3" checked="false" textColor="#666666" text="显示更多选项" />
+                                </vertical>
+                                <vertical id="MirrorsExtraSettings1" visibility="gone" padding="10 8 0 6" w="*" h="auto">
+                                    <Switch id="smartMirrorsPick" w="*" margin="0 3" checked="true" textColor="#000000" text="智能挑选最弱对手" />
+                                    <text text="开启此项后会先找总战力低于我方六分之一的弱队,如果找不到就挨个点开队伍详情计算平均战力,从而找到最弱对手。如果碰到问题可以关闭这个选项,然后就只会挑选第3个对手" textColor="#000000" />
+                                </vertical>
+                                <vertical id="MirrorsExtraSettings2" visibility="gone" padding="10 8 0 6" w="*" h="auto">
+                                    <Switch id="useCVAutoBattle" w="*" margin="0 3" checked="true" textColor="#000000" text="在周回中使用识图自动战斗" />
+                                    <text text="开启此项,可以通过截屏识图自动完成连携。关闭此项,则镜层周回使用简单无脑点第1/2/3个盘来自动完成战斗" textColor="#000000" />
+                                </vertical>
+                            </vertical>
+                        </vertical>
+                        <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
+                            <text text="识图自动战斗(自动点击行动盘(识图,连携))脚本设置" textColor="#000000" padding="5" w="*" bg="#eeeeee" />
+                            <vertical padding="10 6 0 6" w="*" h="auto">
+                                <vertical padding="0 8 0 6" w="*" h="auto">
+                                    <Switch id="toggleCVAutoBattleExtraSettings" w="*" margin="0 3" checked="false" textColor="#666666" text="显示更多选项" />
+                                </vertical>
+                                <vertical id="CVAutoBattleExtraSettings1" visibility="gone" padding="10 8 0 6" w="*" h="auto">
+                                    <Switch id="rootScreencap" w="*" margin="0 3" checked="false" textColor="#000000" text="使用root或adb权限截屏" />
+                                    <text text="部分环境下截屏权限会在一段时间后丢失,或者出现截屏后处理数据时报错崩溃的问题。这些情况下可以开启这个选项,但开启后截图效率会下降" textColor="#000000" />
+                                    <text text="注意!超级用户授权通知会遮挡屏幕、干扰截屏识图,所以务必要关掉这个通知(对模拟器来说,一般可以在系统设置里找到超级用户设置)。也可以改用不会弹出通知的Shizuku来授权" textColor="#FF0000" />
+                                </vertical>
+                                <vertical id="CVAutoBattleExtraSettings2" visibility="gone" padding="10 8 0 6" w="*" h="auto">
+                                    <Switch id="CVAutoBattleDebug" w="*" margin="0 3" checked="false" textColor="#000000" text="识图自动战斗启用调试模式" />
+                                    <text text="开启后,识图自动战斗将不会点击行动盘,只会在保存一些图片后结束运行,以方便排查bug" textColor="#000000" />
+                                </vertical>
+                                <vertical id="CVAutoBattleExtraSettings3" visibility="gone" padding="10 8 0 6" w="*" h="auto">
+                                    <Switch id="CVAutoBattleClickAllSkills" w="*" margin="0 3" checked="true" textColor="#000000" text="使用主动技能" />
+                                    <text text="开启后,从第3回合开始,会放出所有可用的主动技能。如果遇到问题可以关闭" textColor="#000000" />
+                                </vertical>
+                            </vertical>
+                        </vertical>
+                        <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
+                            <text text="副本/活动周回2(备用可选)脚本设置" textColor="#000000" padding="5" w="*" bg="#eeeeee" />
+                            <vertical padding="10 6 0 6" w="*" h="auto">
+                                <text text="活动周回关卡选择:" textColor="#000000" margin="0 5" />
+                                <radiogroup id="battleNo" padding="10 3 0 3">
+                                    <radio id="cb1" text="初级" />
+                                    <radio id="cb2" text="中级" />
+                                    <radio id="cb3" text="高级" checked="true" />
+                                </radiogroup>
+                                <linear margin="0 3">
+                                    <text text="助战x，y坐标自定义:" textColor="#000000" layout_gravity="center_vertical" />
+                                    <input maxLength="4" id="helpx" text="" hint="横坐标" textSize="14" inputType="number|none" />
+                                    <input maxLength="4" id="helpy" text="" hint="纵坐标" textSize="14" inputType="number|none" />
+                                </linear>
+                            </vertical>
+                        </vertical>
+                        <vertical margin="0 5" bg="#ffffff" elevation="1dp" w="*" h="auto">
+                            <text text="关于" textColor="#000000" padding="5" w="*" bg="#eeeeee" />
+                            <linear padding="10 6" bg="#ffffff">
+                                <text id="versionMsg" layout_weight="1" w="*" gravity="center" color="#666666" text="尝试获取最新版本信息" />
+                            </linear>
+                            <linear padding="10 6" bg="#ffffff">
+                                <text id="" layout_weight="1" color="#666666" text="版权声明，本app仅供娱乐学习使用，且永久免费，不可进行出售盈利。作者bilibili 虹之宝玉  群号：453053507" />
+                            </linear>
+                        </vertical>
+                    </vertical>
+                </ScrollView>
+            </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+        </relative>
+    );
+
+    function getTintDrawable(name, tint) {
+        var id = context.getResources().getIdentifier(name, "drawable", context.getPackageName());
+        var raw = AppCompatResources.getDrawable(context, id);
+        var wrapped = DrawableCompat.wrap(raw);
+        DrawableCompat.setTint(wrapped, tint);
+        return wrapped
+    }
+
+    ui.emitter.on("create_options_menu", menu => {
+        //在菜单内显示图标
+        let menuClass = menu.getClass();
+        if(menuClass.getSimpleName().equals("MenuBuilder")){
+            try {
+                let m = menuClass.getDeclaredMethod("setOptionalIconsVisible", java.lang.Boolean.TYPE);
+                m.setAccessible(true);
+                m.invoke(menu, true);
+            } catch(e){
+                log(e);
+            }
+        }
+        //SHOW_AS_ACTION_IF_ROOM在竖屏下不会显示文字,所以不设置
+        let item = menu.add("报告问题");
+        item.setIcon(getTintDrawable("ic_report_black_48dp", colors.WHITE));
+        item.setShowAsAction(MenuItem.SHOW_AS_ACTION_WITH_TEXT);
+        item = menu.add("查看日志");
+        item.setIcon(getTintDrawable("ic_assignment_black_48dp", colors.WHITE));
+        item.setShowAsAction(MenuItem.SHOW_AS_ACTION_WITH_TEXT);
+        item = menu.add("魔纪百科");
+        item.setIcon(getTintDrawable("ic_book_black_48dp", colors.WHITE));
+        item.setShowAsAction(MenuItem.SHOW_AS_ACTION_WITH_TEXT);
+        item = menu.add("模拟抽卡");
+        item.setIcon(getTintDrawable("ic_store_black_48dp", colors.WHITE));
+        item.setShowAsAction(MenuItem.SHOW_AS_ACTION_WITH_TEXT);
+    });
+
+    activity.setSupportActionBar(ui.toolbar);
+
+    ui.emitter.on("options_item_selected", (e, item) => {
+        switch (item.getTitle()) {
+            case "报告问题":
+                if (reportTask && reportTask.isAlive()) {
+                    toastLog("已经在上传了,请稍后再试");
+                } else {
+                    reportTask = threads.start(reportBug);
+                }
+                break;
+            case "查看日志":
+                app.startActivity("console")
+                break;
+            case "魔纪百科":
+                app.openUrl("https://magireco.moe/");
+                break;
+            case "模拟抽卡":
+                app.openUrl("https://rika.ren/~kuro/workspace/playground/");
+                break;
+        }
+        e.consumed = true;
+    });
+
+    //检测AutoJS引擎版本
+
+    //经测试发现app.autojs.versionName不能用
+    //以下数值通过实际运行一遍代码取得，取自Pro 8.8.13-0
+    const lowestVersionCode = 8081200;
+
+    function detectAutoJSVersion() {
+        ui.run(function() {
+            let currentVersionCode = NaN;
+            try {
+                currentVersionCode = parseInt(app.autojs.versionCode);
+            } catch (e) {
+                currentVersionCode = NaN;
+            }
+            if (isNaN(currentVersionCode)) {
+                ui.autojs_ver_text.setText("无法检测 AutoJS Pro 引擎版本\n继续使用可能碰到问题\n推荐下载最新apk安装包进行更新");
+                ui.autojs_ver_vertical.setVisibility(View.VISIBLE);
+                return;
+            }
+            if (currentVersionCode < lowestVersionCode) {
+                ui.autojs_ver_text.setText("AutoJS Pro 引擎版本过低\n当前版本versionCode=["+currentVersionCode+"]\n最低要求versionCode=["+lowestVersionCode+"]\n继续使用可能碰到问题\n推荐下载最新apk安装包进行更新");
+                ui.autojs_ver_vertical.setVisibility(View.VISIBLE);
+                return;
+            }
         });
     }
-    if (!checked && auto.service) {
-        if (device.sdkInt >= 24) {
-            auto.service.disableSelf();
-        } else {
-            toastLog("Android 6.0或以下请到系统设置里手动关闭无障碍服务");
+    detectAutoJSVersion();
+
+    //无障碍开关监控
+    ui.autoService.setOnCheckedChangeListener(function (widget, checked) {
+        if (checked && !auto.service) {
             app.startActivity({
                 action: "android.settings.ACCESSIBILITY_SETTINGS"
             });
+            //部分品牌的手机在有悬浮窗的情况下拒绝开启无障碍服务（目前只发现OPPO是这样）
+            //为了关闭悬浮窗，最简单的办法就是退出脚本
+            ui.run(function () {
+                if (ui["exitOnServiceSettings"].isChecked()) exit();
+            });
         }
-    }
-    ui.autoService.setChecked(auto.service != null)
-});
-ui.showExperimentalFixes.setOnCheckedChangeListener(function (widget, checked) {
-    ui.experimentalFixes.setVisibility(checked?View.VISIBLE:View.GONE);
-});
-//前台服务
-$settings.setEnabled('foreground_service', $settings.isEnabled('foreground_service')); //修正刚安装好后返回错误的数值，点进设置再出来又变成正确的数值的问题
-ui.foreground.setChecked($settings.isEnabled('foreground_service'));
-ui.foreground.setOnCheckedChangeListener(function (widget, checked) {
-    $settings.setEnabled('foreground_service', checked);
-});
-//按音量上键完全退出脚本
-$settings.setEnabled('stop_all_on_volume_up', $settings.isEnabled('stop_all_on_volume_up')); //修正刚安装好后返回错误的数值，点进设置再出来又变成正确的数值的问题
-ui.stopOnVolUp.setChecked($settings.isEnabled('stop_all_on_volume_up'));
-ui.stopOnVolUp.setOnCheckedChangeListener(function (widget, checked) {
-    $settings.setEnabled('stop_all_on_volume_up', checked);
-});
-
-//显示更多选项
-function setToggleListener(key) {
-    ui["toggle"+key+"ExtraSettings"].setOnCheckedChangeListener(function (widget, checked) {
-        for (let i=1; ui[key+"ExtraSettings"+i] != null; i++) {
-            ui[key+"ExtraSettings"+i].setVisibility(checked?View.VISIBLE:View.GONE);
+        if (!checked && auto.service) {
+            if (device.sdkInt >= 24) {
+                auto.service.disableSelf();
+            } else {
+                toastLog("Android 6.0或以下请到系统设置里手动关闭无障碍服务");
+                app.startActivity({
+                    action: "android.settings.ACCESSIBILITY_SETTINGS"
+                });
+            }
         }
+        ui.autoService.setChecked(auto.service != null)
     });
-}
-for (let key of ["Default", "DefaultCrashRestart", "Mirrors", "CVAutoBattle"]) {
-    setToggleListener(key);
-}
+    ui.showExperimentalFixes.setOnCheckedChangeListener(function (widget, checked) {
+        ui.experimentalFixes.setVisibility(checked?View.VISIBLE:View.GONE);
+    });
+    //前台服务
+    $settings.setEnabled('foreground_service', $settings.isEnabled('foreground_service')); //修正刚安装好后返回错误的数值，点进设置再出来又变成正确的数值的问题
+    ui.foreground.setChecked($settings.isEnabled('foreground_service'));
+    ui.foreground.setOnCheckedChangeListener(function (widget, checked) {
+        $settings.setEnabled('foreground_service', checked);
+    });
+    //按音量上键完全退出脚本
+    $settings.setEnabled('stop_all_on_volume_up', $settings.isEnabled('stop_all_on_volume_up')); //修正刚安装好后返回错误的数值，点进设置再出来又变成正确的数值的问题
+    ui.stopOnVolUp.setChecked($settings.isEnabled('stop_all_on_volume_up'));
+    ui.stopOnVolUp.setOnCheckedChangeListener(function (widget, checked) {
+        $settings.setEnabled('stop_all_on_volume_up', checked);
+    });
 
-//回到本界面时，resume事件会被触发
-ui.emitter.on("resume", () => {
-    // 此时根据无障碍服务的开启情况，同步开关的状态
-    ui.autoService.checked = auto.service != null;
-    if (!floatIsActive) {
-        floatUI.main()
-        floatIsActive = true;
-    }
-    if ($settings.isEnabled('foreground_service') != ui.foreground.isChecked())
-        ui.foreground.setChecked($settings.isEnabled('foreground_service'));
-    if ($settings.isEnabled('stop_all_on_volume_up') != ui.stopOnVolUp.isChecked())
-        ui.stopOnVolUp.setChecked($settings.isEnabled('stop_all_on_volume_up'));
-});
-
-//监听刷新事件
-ui.swipe.setOnRefreshListener({
-    onRefresh: function () {
-        //为了看效果延迟一下
-        toUpdate()
-        ui.swipe.setRefreshing(false);
-    },
-});
-//-----------------自定义逻辑-------------------------------------------
-
-var floatIsActive = false;
-// 悬浮窗权限检查
-if (!$floaty.checkPermission()) {
-    toastLog("没有悬浮窗权限\n申请中...");
-    let failed = false;
-    //这里的调用都不阻塞
-    //也许$floaty.requestPermission出问题时未必会抛异常，但startActivity在MIUI上确证会抛异常
-    //所以先尝试startActivity，再尝试$floaty.requestPermission
-    try {
-        app.startActivity({
-            packageName: "com.android.settings",
-            className: "com.android.settings.Settings$AppDrawOverlaySettingsActivity",
-            data: "package:" + context.getPackageName(),
+    //显示更多选项
+    function setToggleListener(key) {
+        ui["toggle"+key+"ExtraSettings"].setOnCheckedChangeListener(function (widget, checked) {
+            for (let i=1; ui[key+"ExtraSettings"+i] != null; i++) {
+                ui[key+"ExtraSettings"+i].setVisibility(checked?View.VISIBLE:View.GONE);
+            }
         });
-    } catch (e) {
-        failed = true;
-        logException(e);
     }
-    if (failed) {
-        failed = false;
-        toastLog("申请悬浮窗权限时出错\n再次申请...");
+    for (let key of ["Default", "DefaultCrashRestart", "Mirrors", "CVAutoBattle"]) {
+        setToggleListener(key);
+    }
+
+    //回到本界面时，resume事件会被触发
+    ui.emitter.on("resume", () => {
+        // 此时根据无障碍服务的开启情况，同步开关的状态
+        ui.autoService.checked = auto.service != null;
+        if (!floatIsActive) {
+            floatUI.main()
+            floatIsActive = true;
+        }
+        if ($settings.isEnabled('foreground_service') != ui.foreground.isChecked())
+            ui.foreground.setChecked($settings.isEnabled('foreground_service'));
+        if ($settings.isEnabled('stop_all_on_volume_up') != ui.stopOnVolUp.isChecked())
+            ui.stopOnVolUp.setChecked($settings.isEnabled('stop_all_on_volume_up'));
+    });
+
+    //监听刷新事件
+    ui.swipe.setOnRefreshListener({
+        onRefresh: function () {
+            //为了看效果延迟一下
+            toUpdate()
+            ui.swipe.setRefreshing(false);
+        },
+    });
+    //-----------------自定义逻辑-------------------------------------------
+
+    var floatIsActive = false;
+    // 悬浮窗权限检查
+    if (!$floaty.checkPermission()) {
+        toastLog("没有悬浮窗权限\n申请中...");
+        let failed = false;
+        //这里的调用都不阻塞
+        //也许$floaty.requestPermission出问题时未必会抛异常，但startActivity在MIUI上确证会抛异常
+        //所以先尝试startActivity，再尝试$floaty.requestPermission
         try {
-            $floaty.requestPermission();
+            app.startActivity({
+                packageName: "com.android.settings",
+                className: "com.android.settings.Settings$AppDrawOverlaySettingsActivity",
+                data: "package:" + context.getPackageName(),
+            });
         } catch (e) {
             failed = true;
             logException(e);
         }
-    }
-    if (failed) {
-        toastLog("申请悬浮窗权限时出错\n请到应用设置里手动授权");
-    } else {
-        toast("请重新启动脚本");
-    }
-    exit();
-} else {
-    floatUI.main();
-    floatIsActive = true;
-}
-
-var storage = storages.create("auto_mr");
-const persistParamList = [
-    "foreground",
-    "stopOnVolUp",
-    "exitOnServiceSettings",
-    "default",
-    "autoReconnect",
-    "justNPC",
-    "helpx",
-    "helpy",
-    "battleNo",
-    "useAuto",
-    "autoFollow",
-    "breakAutoCycleDuration",
-    "forceStopTimeout",
-    "periodicallyKillTimeout",
-    "timeout",
-    "rootForceStop",
-    "rootScreencap",
-    "smartMirrorsPick",
-    "useCVAutoBattle",
-    "CVAutoBattleDebug",
-    "CVAutoBattleClickAllSkills",
-];
-const tempParamList = [
-    "drug1",
-    "drug2",
-    "drug3",
-    "drug4",
-    "drug1num",
-    "drug2num",
-    "drug3num",
-    "drug4num",
-    "apmul",
-];
-
-var idmap = {};
-var field = (new Ids()).getClass().getDeclaredField("ids");
-field.setAccessible(true);
-var iter = field.get(null).keySet().iterator();
-while (iter.hasNext()) {
-    let item = iter.next();
-    idmap[Ids.getId(item)] = item;
-}
-
-function syncValue(key, value) {
-    switch (ui[key].getClass().getSimpleName()) {
-        // input
-        case "JsEditText":
-            if (value !== undefined)
-                ui[key].setText(value)
-            return ui[key].getText() + ""
-        case "Switch":
-        case "CheckBox":
-            if (value !== undefined)
-                ui[key].setChecked(value)
-            return ui[key].isChecked()
-        case "JsSpinner":
-            if (value !== undefined && ui[key].getCount() > value)
-                ui[key].setSelection(value, true)
-            return ui[key].getSelectedItemPosition()
-        case "RadioGroup": {
-            if (value !== undefined && ui[value])
-                ui[value].setChecked(true)
-            let name = "";
-            let id = ui[key].getCheckedRadioButtonId();
-            if (id >= 0)
-                name = idmap[ui[key].getCheckedRadioButtonId()]
-            return name
+        if (failed) {
+            failed = false;
+            toastLog("申请悬浮窗权限时出错\n再次申请...");
+            try {
+                $floaty.requestPermission();
+            } catch (e) {
+                failed = true;
+                logException(e);
+            }
         }
-
-    }
-}
-
-function saveParamIfPersist(key, value) {
-    for (let paramName of persistParamList) {
-        if (paramName === key) {
-            log("保存参数：", key, value);
-            storage.put(key, value);
-        }
-    }
-}
-
-function setOnChangeListener(key) {
-    switch (ui[key].getClass().getSimpleName()) {
-        case "JsEditText":
-            ui[key].addTextChangedListener(
-            new android.text.TextWatcher({
-            afterTextChanged: function (s) {
-                let value = ""+s;
-                saveParamIfPersist(key, value); //直接用s作为参数会崩溃
-                floatUI.adjust(key, value);
-            }
-            })
-            );
-            break;
-        case "CheckBox":
-        case "Switch":
-            ui[key].setOnCheckedChangeListener(
-            function (widget, checked) {
-                for (let i=1; ui[key+"Text"+i]!=null; i++) {
-                    ui[key+"Text"+i].setVisibility(checked?View.VISIBLE:View.GONE);
-                }
-                saveParamIfPersist(key, checked);
-                floatUI.adjust(key, checked);
-            }
-            );
-            break;
-        case "JsSpinner":
-            ui[key].setOnItemSelectedListener(
-            new android.widget.AdapterView.OnItemSelectedListener({
-            onItemSelected: function (spinnerparent, spinnerview, spinnerposition, spinnerid) {
-                saveParamIfPersist(key, spinnerposition);
-                floatUI.adjust(key, spinnerposition);
-            }
-            })
-            );
-            break;
-        case "RadioGroup":
-            ui[key].setOnCheckedChangeListener(
-            new android.widget.RadioGroup.OnCheckedChangeListener({
-            onCheckedChanged: function (group, checkedId) {
-                let name = idmap[checkedId];
-                if (name) {
-                    saveParamIfPersist(key, name);
-                    floatUI.adjust(key, name);
-                }
-            }
-            })
-            );
-            break;
-    }
-}
-
-//限制timeout的取值
-ui["timeout"].addTextChangedListener(
-new android.text.TextWatcher({
-afterTextChanged: function (s) {
-    let str = ""+s;
-    let value = parseInt(str);
-    if (isNaN(value) || value < 100) {
-        s.replace(0, str.length, "5000");
-    }
-}
-})
-);
-
-for (let key of persistParamList) {
-    if (key == "foreground") continue;
-    if (key == "stopOnVolUp") continue;
-    let value = storage.get(key);
-    setOnChangeListener(key); //先设置listener
-    syncValue(key, value);    //如果储存了超出取值范围之外的数据则会被listener重置
-}
-
-function setDrugCheckboxListener(drugname) {
-    ui[drugname].setOnCheckedChangeListener(function (widget, checked) {
-        saveParamIfPersist(drugname, checked);
-        floatUI.adjust(drugname, checked);
-        if (checked) {
-            ui[drugname+"num"].setEnabled(true);
-            ui[drugname+"num"].setText("");
+        if (failed) {
+            toastLog("申请悬浮窗权限时出错\n请到应用设置里手动授权");
         } else {
-            ui[drugname+"num"].setText("0");
-            ui[drugname+"num"].setEnabled(false);
+            toast("请重新启动脚本");
         }
-    });
-}
-
-for (let key of tempParamList) {
-    if (key.match(/^drug\d+$/)) {
-        setDrugCheckboxListener(key);
-        ui[key+"num"].setEnabled(false);
+        exit();
     } else {
-        setOnChangeListener(key);
+        floatUI.main();
+        floatIsActive = true;
     }
-}
 
-//传递当前版本号给floatUI
-floatUI.adjust("version", version);
+    var storage = storages.create("auto_mr");
+    const persistParamList = [
+        "foreground",
+        "stopOnVolUp",
+        "exitOnServiceSettings",
+        "default",
+        "autoReconnect",
+        "justNPC",
+        "helpx",
+        "helpy",
+        "battleNo",
+        "useAuto",
+        "autoFollow",
+        "breakAutoCycleDuration",
+        "forceStopTimeout",
+        "periodicallyKillTimeout",
+        "timeout",
+        "rootForceStop",
+        "rootScreencap",
+        "smartMirrorsPick",
+        "useCVAutoBattle",
+        "CVAutoBattleDebug",
+        "CVAutoBattleClickAllSkills",
+    ];
+    const tempParamList = [
+        "drug1",
+        "drug2",
+        "drug3",
+        "drug4",
+        "drug1num",
+        "drug2num",
+        "drug3num",
+        "drug4num",
+        "apmul",
+    ];
 
-//限制apmul取值
-//digits="01234"貌似不起效，没办法，只能手动实现
-ui["apmul"].setKeyListener(new android.text.method.NumberKeyListener({
-getInputType: function() {
-    return android.text.InputType.TYPE_MASK_VARIATION;
-},
-getAcceptedChars: function () {
-    return ['0', '1', '2', '3', '4'];
-}
-}));
-
-//返回游戏并继续运行脚本按钮点击事件
-ui["task_paused_button"].setOnClickListener(new android.view.View.OnClickListener({
-    onClick: function (view) {
-        floatUI.backToGame();
+    var idmap = {};
+    var field = (new Ids()).getClass().getDeclaredField("ids");
+    field.setAccessible(true);
+    var iter = field.get(null).keySet().iterator();
+    while (iter.hasNext()) {
+        let item = iter.next();
+        idmap[Ids.getId(item)] = item;
     }
-}));
 
-//版本获取
-var refreshUpdateStatus = sync(function () {
-    http.__okhttp__.setTimeout(5000);
-    try {
-        let res = http.get("https://cdn.jsdelivr.net/gh/icegreentee/magireco_autoBattle@latest/project.json");
-        if (res.statusCode != 200) {
-            log("请求失败: " + res.statusCode + " " + res.statusMessage);
+    function syncValue(key, value) {
+        switch (ui[key].getClass().getSimpleName()) {
+            // input
+            case "JsEditText":
+                if (value !== undefined)
+                    ui[key].setText(value)
+                return ui[key].getText() + ""
+            case "Switch":
+            case "CheckBox":
+                if (value !== undefined)
+                    ui[key].setChecked(value)
+                return ui[key].isChecked()
+            case "JsSpinner":
+                if (value !== undefined && ui[key].getCount() > value)
+                    ui[key].setSelection(value, true)
+                return ui[key].getSelectedItemPosition()
+            case "RadioGroup": {
+                if (value !== undefined && ui[value])
+                    ui[value].setChecked(true)
+                let name = "";
+                let id = ui[key].getCheckedRadioButtonId();
+                if (id >= 0)
+                    name = idmap[ui[key].getCheckedRadioButtonId()]
+                return name
+            }
+
+        }
+    }
+
+    function saveParamIfPersist(key, value) {
+        for (let paramName of persistParamList) {
+            if (paramName === key) {
+                log("保存参数：", key, value);
+                storage.put(key, value);
+            }
+        }
+    }
+
+    function setOnChangeListener(key) {
+        switch (ui[key].getClass().getSimpleName()) {
+            case "JsEditText":
+                ui[key].addTextChangedListener(
+                new android.text.TextWatcher({
+                afterTextChanged: function (s) {
+                    let value = ""+s;
+                    saveParamIfPersist(key, value); //直接用s作为参数会崩溃
+                    floatUI.adjust(key, value);
+                }
+                })
+                );
+                break;
+            case "CheckBox":
+            case "Switch":
+                ui[key].setOnCheckedChangeListener(
+                function (widget, checked) {
+                    for (let i=1; ui[key+"Text"+i]!=null; i++) {
+                        ui[key+"Text"+i].setVisibility(checked?View.VISIBLE:View.GONE);
+                    }
+                    saveParamIfPersist(key, checked);
+                    floatUI.adjust(key, checked);
+                }
+                );
+                break;
+            case "JsSpinner":
+                ui[key].setOnItemSelectedListener(
+                new android.widget.AdapterView.OnItemSelectedListener({
+                onItemSelected: function (spinnerparent, spinnerview, spinnerposition, spinnerid) {
+                    saveParamIfPersist(key, spinnerposition);
+                    floatUI.adjust(key, spinnerposition);
+                }
+                })
+                );
+                break;
+            case "RadioGroup":
+                ui[key].setOnCheckedChangeListener(
+                new android.widget.RadioGroup.OnCheckedChangeListener({
+                onCheckedChanged: function (group, checkedId) {
+                    let name = idmap[checkedId];
+                    if (name) {
+                        saveParamIfPersist(key, name);
+                        floatUI.adjust(key, name);
+                    }
+                }
+                })
+                );
+                break;
+        }
+    }
+
+    //限制timeout的取值
+    ui["timeout"].addTextChangedListener(
+    new android.text.TextWatcher({
+    afterTextChanged: function (s) {
+        let str = ""+s;
+        let value = parseInt(str);
+        if (isNaN(value) || value < 100) {
+            s.replace(0, str.length, "5000");
+        }
+    }
+    })
+    );
+
+    for (let key of persistParamList) {
+        if (key == "foreground") continue;
+        if (key == "stopOnVolUp") continue;
+        let value = storage.get(key);
+        setOnChangeListener(key); //先设置listener
+        syncValue(key, value);    //如果储存了超出取值范围之外的数据则会被listener重置
+    }
+
+    function setDrugCheckboxListener(drugname) {
+        ui[drugname].setOnCheckedChangeListener(function (widget, checked) {
+            saveParamIfPersist(drugname, checked);
+            floatUI.adjust(drugname, checked);
+            if (checked) {
+                ui[drugname+"num"].setEnabled(true);
+                ui[drugname+"num"].setText("");
+            } else {
+                ui[drugname+"num"].setText("0");
+                ui[drugname+"num"].setEnabled(false);
+            }
+        });
+    }
+
+    for (let key of tempParamList) {
+        if (key.match(/^drug\d+$/)) {
+            setDrugCheckboxListener(key);
+            ui[key+"num"].setEnabled(false);
+        } else {
+            setOnChangeListener(key);
+        }
+    }
+
+    //传递当前版本号给floatUI
+    floatUI.adjust("version", version);
+
+    //限制apmul取值
+    //digits="01234"貌似不起效，没办法，只能手动实现
+    ui["apmul"].setKeyListener(new android.text.method.NumberKeyListener({
+    getInputType: function() {
+        return android.text.InputType.TYPE_MASK_VARIATION;
+    },
+    getAcceptedChars: function () {
+        return ['0', '1', '2', '3', '4'];
+    }
+    }));
+
+    //切换到新版设置界面按钮点击事件
+    ui["switch_ui_button"].setOnClickListener(new android.view.View.OnClickListener({
+        onClick: function (view) {
+            switchSettingsUI("webview");
+        }
+    }));
+
+    //返回游戏并继续运行脚本按钮点击事件
+    ui["task_paused_button"].setOnClickListener(new android.view.View.OnClickListener({
+        onClick: function (view) {
+            floatUI.backToGame();
+        }
+    }));
+
+    //版本获取
+    var refreshUpdateStatus = sync(function () {
+        http.__okhttp__.setTimeout(5000);
+        try {
+            let res = http.get("https://cdn.jsdelivr.net/gh/icegreentee/magireco_autoBattle@latest/project.json");
+            if (res.statusCode != 200) {
+                log("请求失败: " + res.statusCode + " " + res.statusMessage);
+                ui.run(function () {
+                    ui.versionMsg.setText("获取失败")
+                    ui.versionMsg.setTextColor(colors.parseColor("#666666"))
+                })
+            } else {
+                let resJson = res.body.json();
+                if (parseInt(resJson.versionName.split(".").join("")) <= parseInt(version.split(".").join(""))) {
+                    ui.run(function () {
+                        ui.versionMsg.setText("当前无需更新")
+                        ui.versionMsg.setTextColor(colors.parseColor("#666666"))
+                    });
+                } else {
+                    ui.run(function () {
+                        ui.versionMsg.setText("最新版本为" + resJson.versionName + ",下拉进行更新")
+                        ui.versionMsg.setTextColor(colors.RED)
+                    });
+                }
+            }
+        } catch (e) {
             ui.run(function () {
-                ui.versionMsg.setText("获取失败")
+                ui.versionMsg.setText("请求超时")
                 ui.versionMsg.setTextColor(colors.parseColor("#666666"))
             })
-        } else {
-            let resJson = res.body.json();
-            if (parseInt(resJson.versionName.split(".").join("")) <= parseInt(version.split(".").join(""))) {
-                ui.run(function () {
-                    ui.versionMsg.setText("当前无需更新")
-                    ui.versionMsg.setTextColor(colors.parseColor("#666666"))
-                });
-            } else {
-                ui.run(function () {
-                    ui.versionMsg.setText("最新版本为" + resJson.versionName + ",下拉进行更新")
-                    ui.versionMsg.setTextColor(colors.RED)
-                });
-            }
         }
-    } catch (e) {
-        ui.run(function () {
-            ui.versionMsg.setText("请求超时")
-            ui.versionMsg.setTextColor(colors.parseColor("#666666"))
-        })
-    }
-});
-threads.start(function () {refreshUpdateStatus();});
+    });
+    threads.start(function () {refreshUpdateStatus();});
 
-//版本更新
-function toUpdate() {
-    try {
-        let res = http.get("https://cdn.jsdelivr.net/gh/icegreentee/magireco_autoBattle@latest/project.json");
-        if (res.statusCode != 200) {
-            toastLog("请求超时")
-        } else {
-            let resJson = res.body.json();
-            if (parseInt(resJson.versionName.split(".").join("")) <= parseInt(version.split(".").join(""))) {
-                toastLog("无需更新")
+    //版本更新
+    function toUpdate() {
+        try {
+            let res = http.get("https://cdn.jsdelivr.net/gh/icegreentee/magireco_autoBattle@latest/project.json");
+            if (res.statusCode != 200) {
+                toastLog("请求超时")
             } else {
-                let main_script = http.get("https://cdn.jsdelivr.net/gh/icegreentee/magireco_autoBattle@"+resJson.versionName+"/main.js");
-                let float_script = http.get("https://cdn.jsdelivr.net/gh/icegreentee/magireco_autoBattle@"+resJson.versionName+"/floatUI.js");
-                if (main_script.statusCode == 200 && float_script.statusCode == 200) {
-                    toastLog("更新加载中");
-                    let mainjs = main_script.body.string();
-                    let floatjs = float_script.body.string();
-                    files.write(engines.myEngine().cwd() + "/main.js", mainjs)
-                    files.write(engines.myEngine().cwd() + "/floatUI.js", floatjs)
-                    events.on("exit", function () {
-                        //通过execScriptFile好像会有问题，比如点击悬浮窗QB=>齿轮然后就出现两个QB
-                        //engines.execScriptFile(engines.myEngine().cwd() + "/main.js")
-                        app.launch(context.getPackageName())
-                        toast("更新完毕")
-                    })
-                    engines.stopAll()
+                let resJson = res.body.json();
+                if (parseInt(resJson.versionName.split(".").join("")) <= parseInt(version.split(".").join(""))) {
+                    toastLog("无需更新")
                 } else {
-                    toast("脚本获取失败！这可能是您的网络原因造成的，建议您检查网络后再重新运行软件吧\nHTTP状态码:" + main_script.statusMessage, "," + float_script.statusMessage);
+                    let main_script = http.get("https://cdn.jsdelivr.net/gh/icegreentee/magireco_autoBattle@"+resJson.versionName+"/main.js");
+                    let float_script = http.get("https://cdn.jsdelivr.net/gh/icegreentee/magireco_autoBattle@"+resJson.versionName+"/floatUI.js");
+                    if (main_script.statusCode == 200 && float_script.statusCode == 200) {
+                        toastLog("更新加载中");
+                        let mainjs = main_script.body.string();
+                        let floatjs = float_script.body.string();
+                        files.write(engines.myEngine().cwd() + "/main.js", mainjs)
+                        files.write(engines.myEngine().cwd() + "/floatUI.js", floatjs)
+                        events.on("exit", function () {
+                            //通过execScriptFile好像会有问题，比如点击悬浮窗QB=>齿轮然后就出现两个QB
+                            //engines.execScriptFile(engines.myEngine().cwd() + "/main.js")
+                            app.launch(context.getPackageName())
+                            toast("更新完毕")
+                        })
+                        engines.stopAll()
+                    } else {
+                        toast("脚本获取失败！这可能是您的网络原因造成的，建议您检查网络后再重新运行软件吧\nHTTP状态码:" + main_script.statusMessage, "," + float_script.statusMessage);
+                    }
                 }
             }
-        }
 
-    } catch (error) {
-        toastLog("请求超时，可再一次尝试")
+        } catch (error) {
+            toastLog("请求超时，可再一次尝试")
+        }
     }
 }
-
+//改变参数时instantToast反馈
 floatUI.enableToastParamChanges();

--- a/main.js
+++ b/main.js
@@ -8,7 +8,7 @@ importClass(Packages.androidx.core.graphics.drawable.DrawableCompat)
 importClass(Packages.androidx.appcompat.content.res.AppCompatResources)
 
 var Name = "AutoBattle";
-var version = "5.2.0";
+var version = "5.3.0";
 var appName = Name + " v" + version;
 
 //注意:这个函数只会返回打包时的版本，而不是在线更新后的版本！

--- a/project.json
+++ b/project.json
@@ -5,7 +5,7 @@
         "build"
     ],
     "packageName": "top.momoe.auto",
-    "versionName": "5.2.0",
+    "versionName": "5.3.0",
     "versionInfo": "",
     "versionCode": 1,
     "icon":"./images/icon.png",


### PR DESCRIPTION
现在只是可以在新旧界面之间切换，新界面还没真正开始适配。

目前打算先适配好UI，再尝试把floatUI.js拆分成模块。

autoWebview在这里添加为子模块，现在还是指向我的仓库，以后可以改。而且我打算不再忽略autoWebview在跑完`npm run build`之后保存在`dist`子目录里的结果，已经从`.gitignore`里去掉了，打算直接把他提交上传，然后就可以走JSDelivr下载。（不知道这个行为是否妥当？）

--------

以后拆分成模块之后，应该还是不能按需加载模块，主要是因为即便拆分出模块来，模块之间也存在依赖关系。而且检测root权限、截屏权限、刘海屏参数之类的还是需要在脚本启动的时候做，需要保存一个状态（尤其是截屏权限，因为AutoJS本身的蛋疼限制，`requestScreenCapture`申请截屏权限不能调用第二次）。

大概的填坑方向：

1. AutoJS端，大概是`main.js`负责（读取本地文件，而不是从WebView端直接把函数代码传过来）加载所有模块（旧版设置界面则分离到独立的`settingsUI`模块里去）、然后继续开启设置界面、悬浮窗，再接受callAJ来更新参数。启动/停止脚本还是像现在这样由悬浮窗负责管理（蓝色启动按钮，或黄色按钮开启脚本临时选择菜单）。
2. `main.js`里优先让Webview使用本地的`file:`协议URL，加载本地的网页，如果本地没有网页文件（比如刚刚从旧版在线更新上来）就用在线的URL，然后就可以在线更新了。
3. 在线更新打算在Webview端做，目前我打算手写在线更新的代码，大概[像这样下载文件](https://github.com/segfault-bilibili/magireco_autoBattle/blob/fetchapi-demo/test.html)，然后把下载好的文件保存到本地。主要是现在对前端还是一窍不通……现在我只翻到Webpack的文档里貌似是有先遍历文件再自动注入遍历结果这个功能的（不知道我误解了没有），而且我看它也有subresource integrity的插件。也许以后知道Webpack啥的都怎么玩之后就可以完全交给Webpack。实在不行，还是用我熟悉的套路：在Git bash里边执行shell脚本来自动生成在线更新文件下载列表以及对应的哈希值。

我不打算把AutoJS端执行的脚本跟Webview搞到一起，因为：

1. 我感觉这样也许不方便调试。JS代码被压缩丑化后很显然就基本不可读了，貌似还要加载一个map，目前我还没试过这个（而且我平时基本没有在用VSCode，MuMu模拟器里还装不了AutoJS Pro），我还不知道VSCode的AutoJS插件能不能支持这种情况下的调试。
2. 识图自动战斗里，我搞了一个自动回收图片的机制，它是依赖行号的，每次生成图片时，都会捕获调用栈，用调用栈里的源码文件名和行号信息来区分图片的用途，避免搞混。（这样每次新生成图片都登记在册，于是在回合结束时就可以一口气全部回收掉，避免内存泄漏）。