### PR TITLE
尝试点开AP药选择窗口的最大检测次数改为50次,而且多次失败后不直接停止脚本运行

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -3491,7 +3491,7 @@ function algo_init() {
             log("继续嗑药");
 
             //确保AP药选择窗口已经打开
-            let ap_refill_title_attempt_max = 1500;
+            let ap_refill_title_attempt_max = 50;
             for (let attempt=0; attempt<ap_refill_title_attempt_max; attempt++) {
                 log("等待AP药选择窗口出现...");
                 ap_refill_title_popup = findPopupInfoDetailTitle(string.ap_refill_title, false);
@@ -3518,8 +3518,9 @@ function algo_init() {
                     return result;
                 }
                 if (attempt == ap_refill_title_attempt_max-1) {
-                    log("长时间等待后，AP药选择窗口仍然没有出现，退出");
-                    stopThread();
+                    log("多次尝试后，AP药选择窗口仍然没有出现");
+                    result = "error";
+                    return result;
                 }
                 if (attempt % 5 == 0) {
                     log("点击AP按钮");


### PR DESCRIPTION
2021-08-06晚上接到一个奇怪的反馈，称当时游戏在助战选择界面，脚本不动了。日志（见后）里看到点击AP按钮弹出AP药选择窗口似乎没有成功。很遗憾当时没有留下控件快照。

这个问题的情况还不是很清楚。不过想了想还是决定把refillAP里的`ap_refill_title_attempt_max`从1500改小到50。这个循环内每一轮都等待0.2秒，每5轮循环才点击一次，于是就约等于每1秒才尝试点击一次。

一般认为点开AP药选择窗口不会出什么问题（经过测试，即便暂时断网，游戏里点击AP按钮也仍然可以照常打开AP药选择窗口），但万一这里出了幺蛾子，应该也不需要反复重试等待5分多钟（1500*0.2s=300s=5min），而且如果直接停止线程退出脚本运行了，也就不能自动重开了。所以，这里就改成不退出，于是万一出了幺蛾子也可以交给自动重开来解决（检测到闪退，或者检测到卡在同一个状态时间太久）。

```
021-08-05 21:42:00.526/DEBUG: 更新参数： drug1 true
2021-08-05 21:42:00.536/DEBUG: 更新参数： drug1num 
2021-08-05 21:42:01.106/DEBUG: 更新参数： drug2 true
2021-08-05 21:42:01.117/DEBUG: 更新参数： drug2num 
2021-08-05 21:42:07.678/DEBUG: 保存参数： useAuto true
2021-08-05 21:42:07.682/DEBUG: 更新参数： useAuto true
2021-08-05 21:42:15.571/DEBUG: 更新参数： apmul 2
2021-08-05 21:43:05.083/DEBUG: 保存参数： justNPC true
2021-08-05 21:43:05.088/DEBUG: 更新参数： justNPC true
2021-08-05 21:43:25.522/DEBUG: 执行 副本周回(剧情/活动通用) 脚本
2021-08-05 21:43:25.598/DEBUG: 区服 zh_Hans
2021-08-05 21:43:25.606/DEBUG: detected_screen { width: 2400, height: 1080, type: 'wider' } detected_gameoffset { x: 240, y: 0, center: { y: 0 }, bottom: { y: 0 } }
2021-08-05 21:43:26.228/DEBUG: EditText bounds Rect(285, 0 - 2205, 132)
2021-08-05 21:43:26.243/DEBUG: detected_gamebounds Rect(285, 0 - 2205, 1080)
2021-08-05 21:43:26.245/DEBUG: currentRotation 1 initialRotation 0
2021-08-05 21:43:26.246/DEBUG: relativeRotation 1
2021-08-05 21:43:26.251/DEBUG: safeInsets before rotation { Left: 0, Top: 91, Right: 0, Bottom: 0 }
2021-08-05 21:43:26.254/DEBUG: safeInsets after rotation { Left: 91, Top: 0, Right: 0, Bottom: 0 }
2021-08-05 21:43:26.255/DEBUG: isGameoffsetAdjusted true
2021-08-05 21:43:26.260/DEBUG: detected_gameoffset { x: 285.5, y: 0, center: { y: 0 }, bottom: { y: 0 } }
2021-08-05 21:43:26.264/DEBUG: 周回已开始。
因为没有动作录制数据,
所以未启用闪退自动重开功能。
2021-08-05 21:43:26.264/DEBUG: 检测初始状态...
2021-08-05 21:43:27.105/DEBUG: 弹窗检测结果 null
2021-08-05 21:43:27.405/DEBUG: STATE_SUPPORT
2021-08-05 21:43:28.129/DEBUG: 根据情况,如果需要,就使用AP回复药
2021-08-05 21:43:28.759/DEBUG: 当前AP:28/121
2021-08-05 21:43:28.759/DEBUG: 要嗑药到2倍AP上限,即242AP
2021-08-05 21:43:28.760/DEBUG: 当前AP尚未达到设置的上限倍数
2021-08-05 21:43:28.760/DEBUG: 
第1种回复药
已启用
个数限制:NaN个
2021-08-05 21:43:28.760/DEBUG: 继续嗑药
2021-08-05 21:43:28.760/DEBUG: 等待AP药选择窗口出现...
2021-08-05 21:43:28.959/DEBUG: 点击AP按钮
2021-08-05 21:43:29.276/DEBUG: 使用无障碍服务模拟点击坐标 1327,56
2021-08-05 21:43:30.282/DEBUG: 点击完成
2021-08-05 21:43:30.484/DEBUG: 等待AP药选择窗口出现...
2021-08-05 21:43:30.870/DEBUG: 等待AP药选择窗口出现...
2021-08-05 21:43:31.250/DEBUG: 等待AP药选择窗口出现...
2021-08-05 21:43:31.642/DEBUG: 等待AP药选择窗口出现...
2021-08-05 21:43:32.032/DEBUG: 等待AP药选择窗口出现...
2021-08-05 21:43:32.285/DEBUG: 点击AP按钮
2021-08-05 21:43:32.628/DEBUG: 使用无障碍服务模拟点击坐标 1327,56
2021-08-05 21:43:33.632/DEBUG: 点击完成
2021-08-05 21:43:33.835/DEBUG: 等待AP药选择窗口出现...
2021-08-05 21:43:34.268/DEBUG: 等待AP药选择窗口出现...
2021-08-05 21:43:34.703/DEBUG: 等待AP药选择窗口出现...
2021-08-05 21:43:35.139/DEBUG: 等待AP药选择窗口出现...
2021-08-05 21:43:35.558/DEBUG: 等待AP药选择窗口出现...
2021-08-05 21:43:35.721/DEBUG: 点击AP按钮
2021-08-05 21:43:36.069/DEBUG: 使用无障碍服务模拟点击坐标 1327,56
2021-08-05 21:43:37.073/DEBUG: 点击完成
2021-08-05 21:43:37.275/DEBUG: 等待AP药选择窗口出现...
2021-08-05 21:43:37.693/DEBUG: 等待AP药选择窗口出现...
2021-08-05 21:43:38.096/DEBUG: 等待AP药选择窗口出现...
2021-08-05 21:43:38.473/DEBUG: 等待AP药选择窗口出现...
2021-08-05 21:43:38.804/DEBUG: 等待AP药选择窗口出现...
2021-08-05 21:43:38.959/DEBUG: 点击AP按钮
2021-08-05 21:43:39.121/DEBUG: 停止脚本
2021-08-05 21:43:39.530/DEBUG: 使用无障碍服务模拟点击坐标 1327,56
2021-08-05 21:43:40.569/DEBUG: 关闭所有无主对话框...
2021-08-05 21:43:40.570/DEBUG: 等待无主对话框全部清空...
2021-08-05 21:43:40.572/DEBUG: 无主对话框已全部清空
2021-08-05 21:43:40.731/DEBUG: 已停止之前的脚本
2021-08-05 21:43:40.789/DEBUG: 关闭所有无主对话框...
2021-08-05 21:43:40.790/DEBUG: 等待无主对话框全部清空...
2021-08-05 21:43:40.790/DEBUG: 无主对话框已全部清空
...
2021-08-05 21:48:01.504/DEBUG: 正在上传日志和最近一次的快照,请耐心等待...
2021-08-05 21:48:01.504/DEBUG: AutoBattle v5.2.0
2021-08-05 21:48:01.524/DEBUG: 
参数:
 { version: '5.2.0',
  helpx: '',
  helpy: '',
  battleNo: 'cb3',
  drug1: true,
  drug2: true,
  drug3: false,
  autoReconnect: true,
  justNPC: true,
  drug4: false,
  drug1num: '',
  drug2num: '',
  drug3num: '0',
  drug4num: '0',
  default: 0,
  useAuto: true,
  autoFollow: true,
  breakAutoCycleDuration: '',
  forceStopTimeout: '',
  periodicallyKillTimeout: '',
  apmul: '2',
  timeout: '5000',
  rootForceStop: true,
  rootScreencap: false,
  smartMirrorsPick: true,
  useCVAutoBattle: true,
  CVAutoBattleDebug: false,
  CVAutoBattleClickAllSkills: true,
  firstRequestPrivilege: true,
  killSelf: false,
  privilege: null,
  cutoutParams: 
   { rotation: 0,
     cutout: DisplayCutout{insets=Rect(0, 91 - 0, 0) boundingRect={Bounds=[Rect(0, 0 - 0, 0), Rect(508, 0 - 572, 91), Rect(0, 0 - 0, 0), Rect(0, 0 - 0, 0)]}} } }
2021-08-05 21:48:01.524/DEBUG: Android API Level 29
2021-08-05 21:48:01.525/DEBUG: 屏幕分辨率 1080 2400
2021-08-05 21:48:01.525/DEBUG: 
brand Redmi
device gauguinpro
model M2007J17C
product gauguinpro
hardware qcom
2021-08-05 21:48:01.535/DEBUG: 要上传的快照文件名 2021-7-23_20-48-4.xml
2021-08-05 21:48:01.536/DEBUG: 快照大小 5470字节 5447字符
```