### PR TITLE
修正isGameDead/reLogin/detectInitialState中掉线检测失效/不全面的bug

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -2918,6 +2918,7 @@ function algo_init() {
             "connection_lost",
             "auth_error",
             "generic_error",
+            "error_occurred",
         ],
         zh_Hans: [
             "请选择支援角色",
@@ -2943,6 +2944,7 @@ function algo_init() {
             "连线超时",
             "认证错误",//被踢下线
             "错误",
+            "发生错误",//出现场景(之一)是登录时掉线
         ],
         zh_Hant: [
             "請選擇支援角色",
@@ -2968,6 +2970,7 @@ function algo_init() {
             "連線超時",
             "認證錯誤",//被踢下线
             "錯誤",
+            "發生錯誤",
         ],
         ja: [
             "サポートキャラを選んでください",
@@ -2993,6 +2996,7 @@ function algo_init() {
             "通信エラー",
             "認証エラー",//这个是脑补的。实际上日服貌似只能引继，没有多端登录，所以也就没有被“顶号”、被踢下线……
             "エラー",
+            "エラー",//不是非常确定
         ],
     };
 
@@ -3187,7 +3191,7 @@ function algo_init() {
         if (bypassPopupCheck.get() == 0) do {
             let found_popup = null;
             try {
-                found_popup = findPopupInfoDetailTitle(["connection_lost", "auth_error", "generic_error"].map((val) => string[val]));
+                found_popup = findPopupInfoDetailTitle(["connection_lost", "auth_error", "generic_error", "error_occurred"].map((val) => string[val]));
             } catch (e) {
                 logException(e);
                 found_popup = null;
@@ -3936,7 +3940,7 @@ function algo_init() {
             if (found_popup != null) {
                 log("发现弹窗 标题: \""+found_popup.title+"\"");
                 let expected_titles = [];
-                for (let error_type of ["connection_lost", "auth_error", "generic_error"]) {
+                for (let error_type of ["connection_lost", "auth_error", "generic_error", "error_occurred"]) {
                     expected_titles.push(string[error_type]);
                 }
                 let matched_title = expected_titles.find((val) => val == found_popup.title);
@@ -4979,7 +4983,7 @@ function algo_init() {
             log("弹窗检测结果", found_popup);
             if (found_popup == null) break;
             let expected_titles = [];
-            for (let error_type of ["connection_lost", "auth_error", "generic_error"]) {
+            for (let error_type of ["connection_lost", "auth_error", "generic_error", "error_occurred"]) {
                 expected_titles.push(string[error_type]);
             }
             let matched_title = expected_titles.find((val) => val == found_popup.title);

--- a/floatUI.js
+++ b/floatUI.js
@@ -3187,7 +3187,7 @@ function algo_init() {
         if (bypassPopupCheck.get() == 0) do {
             let found_popup = null;
             try {
-                found_popup = findPopupInfoDetailTitle(["connection_lost", "auth_error", "generic_error"]);
+                found_popup = findPopupInfoDetailTitle(["connection_lost", "auth_error", "generic_error"].map((val) => string[val]));
             } catch (e) {
                 logException(e);
                 found_popup = null;


### PR DESCRIPTION
#167 不小心引入了bug，导致isGameDead里的掉线检测失效了，现在修正。

除此之外，掉线的时候还可能是出现“发生错误”弹窗，这种弹窗之前不在检测范围内。