### PR TITLE
修正现有助战选择没考虑“未设定”的问题

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -2825,10 +2825,15 @@ function algo_init() {
             //最后一个Lv/ATK/DEF/HP控件后面已经没有下一个Lv/ATK/DEF/HP控件了，用finalIndex；其余的往后推一个即可
             let nextIndex = i >= arr.length - 1 ? finalIndex : arr[i+1];
 
-            //倒过来从后往前搜Pt控件，防止碰到类似Pt的恶搞玩家名
-            let ptIndex = PtLikeIndices.reverse().find((val) => val > index && val < nextIndex);
-            //恢复原状
-            PtLikeIndices.reverse();
+            //从前往后找到所有像是Pt的控件
+            let ptPossibleIndices = PtLikeIndices
+                .filter((val) => val > index && val < nextIndex)
+                .filter(
+                         (val) => AllElements.slice(index + 1, val)/* 避免未设定角色的助战插入进来干扰 */
+                                             .find((element) => getContent(element) == string.support_chara_not_set) == null
+                       );
+            //取最后一个，防止碰到恶搞玩家名
+            let ptIndex = ptPossibleIndices.length > 0 ? ptPossibleIndices[ptPossibleIndices.length-1] : null;
 
             if (ptIndex != null) {
                 let PtContent = getContent(AllElements[ptIndex]);

--- a/floatUI.js
+++ b/floatUI.js
@@ -2689,6 +2689,7 @@ function algo_init() {
         var hasError = false;
         //Lv/ATK/DEF/HP [Rank] 玩家名 [最终登录] Pt
         //Lv/ATK/DEF/HP 玩家名 [Rank] [最终登录] Pt
+        //如果助战玩家未设定当前属性的角色，则缺失Lv/ATK/DEF/HP，但仍然有Rank、玩家名、最终登录和Pt
         let AllElements = [];
         let uicollection = packageName(string.package_name).find();
         for (let i=0; i<uicollection.length; i++) {
@@ -2741,9 +2742,20 @@ function algo_init() {
 
             if (rankIndex != null && lastLoginIndex != null) {
                 //在Lv/ATK/DEF/HP后找到Rank和上次登录，就是玩家的Lv/ATK/DEF/HP；否则是NPC或恶搞玩家名
-                PlayerLvIndices.push(index);
+                //但是还要排除一种可能：未设定助战角色
+                let ptIndex = PtLikeIndices.find((val) => val > rankIndex && val > lastLoginIndex);
+                if (ptIndex == null) {
+                    log("在第"+(arr.length-i)+"个Lv/ATK/DEF/HP控件后,找到了Rank和上次登录,却没找到Pt");
+                    return;
+                }
+                if (AllElements.slice(index + 1, ptIndex).find((val) => getContent(val) == string.support_chara_not_set) != null) {
+                    log("在第"+(arr.length-i)+"个Lv/ATK/DEF/HP控件后,找到了Rank和上次登录,匹配到了未设定角色(不可点击)的助战,视为NPC");
+                    NPCLvIndices.push(index);
+                } else {
+                    PlayerLvIndices.push(index);
+                }
                 AllLvIndices.push(index);
-                return
+                return;
             }
             if (rankIndex != null && lastLoginIndex == null) {
                 log("在第"+(arr.length-i)+"个Lv/ATK/DEF/HP控件后,找到了Rank,却没找到上次登录");
@@ -2978,6 +2990,7 @@ function algo_init() {
     const strings = {
         name: [
             "support",
+            "support_chara_not_set",
             "ap_refill_title",
             "ap_refill_button",
             "ap_refill_popup",
@@ -3005,6 +3018,7 @@ function algo_init() {
         ],
         zh_Hans: [
             "请选择支援角色",
+            "未设定",
             "AP回复",
             "回复",
             "回复确认",
@@ -3032,6 +3046,7 @@ function algo_init() {
         ],
         zh_Hant: [
             "請選擇支援角色",
+            "未設定",
             "AP回復",
             "回復",
             "回復確認",
@@ -3059,6 +3074,7 @@ function algo_init() {
         ],
         ja: [
             "サポートキャラを選んでください",
+            "未設定",
             "AP回復",
             "回復",
             "回復確認",

--- a/floatUI.js
+++ b/floatUI.js
@@ -2743,14 +2743,22 @@ function algo_init() {
             if (rankIndex != null && lastLoginIndex != null) {
                 //在Lv/ATK/DEF/HP后找到Rank和上次登录，就是玩家的Lv/ATK/DEF/HP；否则是NPC或恶搞玩家名
                 //但是还要排除一种可能：未设定助战角色
+                //在（疑似）Rank和上次登录时间之后找Pt，尽量确保找到的Pt不是恶搞玩家名（比如“+60”）
                 let ptIndex = PtLikeIndices.find((val) => val > rankIndex && val > lastLoginIndex);
                 if (ptIndex == null) {
-                    log("在第"+(arr.length-i)+"个Lv/ATK/DEF/HP控件后,找到了Rank和上次登录,却没找到Pt");
+                    log("助战选择出错,在第"+(arr.length-i)+"个Lv/ATK/DEF/HP控件后,找到了Rank和上次登录,却没找到Pt");
+                    hasError = true;
                     return;
                 }
                 if (AllElements.slice(index + 1, ptIndex).find((val) => getContent(val) == string.support_chara_not_set) != null) {
-                    log("在第"+(arr.length-i)+"个Lv/ATK/DEF/HP控件后,找到了Rank和上次登录,匹配到了未设定角色(不可点击)的助战,视为NPC");
-                    NPCLvIndices.push(index);
+                    log("在第"+(arr.length-i)+"个Lv/ATK/DEF/HP控件后,找到了Rank和上次登录,还有\"未设定\"");
+                    if (PtLikeIndices.find((val) => val > index && val < ptIndex) != null) {
+                        log("应该是NPC");
+                        NPCLvIndices.push(index);
+                    } else {
+                        log("应该是恶搞玩家名\"未设定\"");
+                        PlayerLvIndices.push(index);
+                    }
                 } else {
                     PlayerLvIndices.push(index);
                 }


### PR DESCRIPTION
因为 #214 目前暂时的想法是新发布一个基于识图的脚本，主要精力也转移过去，旧的基于无障碍的脚本可能不太顾得着了。

----------------

马上还是要重写一个基于识图的助战选择。

但现有的助战选择也可以留下来作为识图用不了时的后备选项。

----------------

有些玩家的支援队伍里，部分属性并没有设定角色，于是切到那个属性后，列表里就会出现一个不可点击的“未设定”助战。

在控件列表中，这个“未设定”助战没有Lv/HP/ATK/DEF，但是有Rank、有上次登录时间、有Pt。

1. 如果“未设定”插入到NPC后，就会导致NPC助战被错判成玩家助战。脚本假设NPC助战没有Rank和登录时间，只有玩家助战有这两项，然后就从NPC的Lv/HP/ATK/DEF开始往后搜索到了“未设定”的Rank和登录时间，于是就误以为这不是NPC而是个玩家。

2. 如果“未设定”插入到玩家后，就会导致搞错Pt加成。比如，本来是互关好友+60Pt，如果有个单fo“未设定”好友+20Pt插入到这个互关好友后面，因为脚本（为了避免碰到类似“+60”这种恶搞玩家名）是倒着搜寻Pt控件的，于是就先碰到了“未设定”插入进来的+20Pt，把+60Pt误识别成+20Pt。