### PR TITLE
避免重新登录时误触碎钻复活确认按钮；定时杀进程增加考虑尽量不打断战斗

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -4321,14 +4321,14 @@ function algo_init() {
                 return false;//调用者会杀进程
             }
 
-            if (elapsedTime > 2 * 60 * 1000) {
+            if (elapsedTime > 60 * 1000) {
                 let btnName = null;
                 if (!isRecoverBtnClicked) {
                     //“恢复战斗”按钮和断线重连的“否”重合，很蛋疼，但是没有控件可以检测，没办法
                     //不过恢复战斗又掉线的几率并不高，而且即便又断线了，点“否”后游戏会重新登录，然后还是可以再点一次“恢复战斗”
                     //只有第一次点击恢复战斗按钮,然后就改为总是点击放弃战斗按钮,这样才能避免误触碎钻复活确认
                     isRecoverBtnClicked = true;
-                    log("超过2分钟还没登录成功,准备点击一次恢复战斗按钮");
+                    log("超过1分钟还没登录成功,准备点击一次恢复战斗按钮");
                     btnName = "recover"
                 } else {
                     btnName = "abandon";

--- a/floatUI.js
+++ b/floatUI.js
@@ -5748,7 +5748,7 @@ function algo_init() {
                     if (state == STATE_BATTLE) {
                         //如果当前还是战斗状态就多等一段时间
                         let gracePeriod = parseInt(limit.periodicallyKillGracePeriod);
-                        if (!isNaN(gracePeriod) && gracePeriod > 0) deadlineTime += gracePeriod;
+                        if (!isNaN(gracePeriod) && gracePeriod > 0) deadlineTime += gracePeriod * 1000;
                     }
                     if (new Date().getTime() > deadlineTime) {
                         let logString = "";

--- a/floatUI.js
+++ b/floatUI.js
@@ -4256,6 +4256,18 @@ function algo_init() {
 
         var startTime = new Date().getTime();
 
+        const recoverOrAbandonBtn = {
+            recover: {
+                description: "恢复战斗",
+                convertedPoint: convertCoords(clickSets.recover_battle),
+            },
+            abandon: {
+                description: "放弃战斗",
+                convertedPoint: convertCoords(clickSets.reconection),
+            },
+        }
+        var isRecoverBtnClicked = false;
+
         toastLog("重新登录...");
         while (true) {
             if (isGameDead(1000) == "crashed") {
@@ -4302,17 +4314,30 @@ function algo_init() {
                 return true;
             }
 
-            if (new Date().getTime() - startTime > 10 * 60 * 1000) {
+            let elapsedTime = new Date().getTime() - startTime;
+            if (elapsedTime > 10 * 60 * 1000) {
                 toastLog("超过10分钟没有登录成功");
                 return false;//调用者会杀进程
             }
 
-            //“恢复战斗”按钮和断线重连的“否”重合，很蛋疼，但是没有控件可以检测，没办法
-            //不过恢复战斗又掉线的几率并不高，而且即便又断线了，点“否”后游戏会重新登录，然后还是可以再点一次“恢复战斗”
-            log("点击恢复战斗按钮区域...");
-            click(convertCoords(clickSets.recover_battle));
-            log("点击恢复战斗按钮区域完成,等待1秒...");
-            sleep(1000);
+            if (elapsedTime > 2 * 60 * 1000) {
+                let btnName = null;
+                if (!isRecoverBtnClicked) {
+                    //“恢复战斗”按钮和断线重连的“否”重合，很蛋疼，但是没有控件可以检测，没办法
+                    //不过恢复战斗又掉线的几率并不高，而且即便又断线了，点“否”后游戏会重新登录，然后还是可以再点一次“恢复战斗”
+                    //只有第一次点击恢复战斗按钮,然后就改为总是点击放弃战斗按钮,这样才能避免误触碎钻复活确认
+                    isRecoverBtnClicked = true;
+                    log("超过2分钟还没登录成功,准备点击一次恢复战斗按钮");
+                    btnName = "recover"
+                } else {
+                    btnName = "abandon";
+                }
+                let btn = recoverOrAbandonBtn[btnName];
+                log("点击"+btn.description+"按钮区域...");
+                click(btn.convertedPoint);
+                log("点击"+btn.description+"按钮区域完成,等待1秒...");
+                sleep(1000);
+            }
             log("点击OK按钮区域...");
             click(convertCoords(clickSets.dataDownloadOK));
             log("点击OK按钮区域完成,等待1秒...");

--- a/main.js
+++ b/main.js
@@ -189,11 +189,17 @@ ui.layout(
                             </vertical>
                             <vertical id="DefaultCrashRestartExtraSettings4" visibility="gone" padding="10 8 0 0" w="*" h="auto">
                                 <linear>
-                                    <text text="无条件杀进程重开,每隔" textColor="#000000" />
+                                    <text text="定时杀进程重开,每隔" textColor="#000000" />
                                     <input maxLength="5" id="periodicallyKillTimeout" hint="留空即不强关重开" text="3600" textSize="14" inputType="number|none" />
-                                    <text text="秒一次" textColor="#000000" />
+                                    <text text="秒一次," textColor="#000000" />
                                 </linear>
-                                <text text="（只有在启用自动重开功能时才会杀进程）有的时候游戏会发生内存泄露,内存占用持续上升直至爆炸,可能导致脚本进程也被杀死。这种情况下,设置假死检测超时、打断官方自动续战可能都没用,于是就不得不设置这个万不得已的选项。一般设为1小时(3600秒)左右。" textColor="#000000" />
+                                <text text="但如果战斗还没结束," textColor="#000000" />
+                                <linear>
+                                    <text text="就再多等" textColor="#000000" />
+                                    <input maxLength="5" id="periodicallyKillGracePeriod" hint="留空即不等待战斗结束" text="540" textSize="14" inputType="number|none" />
+                                    <text text="秒后再杀进程" textColor="#000000" />
+                                </linear>
+                                <text text="（只有在启用自动重开功能时才会杀进程）有的时候游戏会发生内存泄露,内存占用持续上升直至爆炸,可能导致脚本进程也被杀死。这种情况下,设置假死检测超时、打断官方自动续战可能都没用,于是就不得不设置这个万不得已的选项。一般设为1小时(3600秒)杀一次进程,如果战斗还没结束就再多等9分钟(540秒)。" textColor="#000000" />
                                 <text text="警告:在使用官方自动续战的情况下,定时杀进程会显著加快互关好友助战的消耗速度,如果助战冷却速度赶不上消耗的速度,导致互关好友助战耗尽,而且又没有NPC助战的话,脚本会继续使用单向好友和路人,导致Pt收益大幅下降(降为互关好友的三分之一)!" textColor="#ff0000"/>
                                 <text text="所以请不要把无条件定时杀进程的时间间隔设置得太短!另外,推荐检查一下“只对优选助战使用官方自动续战”设置!" textColor="#ff0000"/>
                             </vertical>
@@ -657,6 +663,7 @@ const persistParamList = [
     "breakAutoCycleDuration",
     "forceStopTimeout",
     "periodicallyKillTimeout",
+    "periodicallyKillGracePeriod",
     "timeout",
     "rootForceStop",
     "rootScreencap",


### PR DESCRIPTION
如果没有开启防断线模式（打输了=>在询问是否碎钻复活的界面傻等=>触发假死自动重开=>重新登录，其实是SL了，询问是否恢复战斗=>脚本自动点击恢复战斗=>再次打输=>再次询问是否碎钻复活，然后同下文）；或者抛开防断线模式不谈，恰巧碰上了重开游戏后需要恢复战斗、恢复战斗后又打输了的情况，因为脚本没有识图、是闭着眼点击恢复战斗按钮所在的位置，这个位置正好和碎钻复活确认按钮重合，所以就会痛失5魔法石。然后（预计）就会（因为碎钻后游戏内建自动战斗会自动停用）进入傻等玩家点击行动盘=>玩家没点击，触发假死自动重开=>恢复战斗=>傻等玩家点击行动盘=>玩家没点击，触发假死自动重开的蛋疼死循环……