### PR TITLE
如果在勾选启用只对优选助战使用官方自动续战的情况下又对助战优选列表留空,则认为可以启用官方自动续战(前提是开启了官方自动续战)

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -5842,7 +5842,7 @@ function algo_init() {
                     if (findID("nextPageBtn")) {
                         state = STATE_TEAM;
                         toastLog("警告: 脚本不知道现在选了哪一关!"+
-                                 "本轮"+((limit.useAuto&&(!limit.autoForPreferredOnly||lastFoundPreferredChara))?"官方周回":"战斗")+"结束后,\n"+
+                                 "本轮"+((limit.useAuto&&(!limit.autoForPreferredOnly||(limit.preferredSupportCharaNames===""||limit.preferredSupportCharaNames==null||lastFoundPreferredChara)))?"官方周回":"战斗")+"结束后,\n"+
                                  "可能无法自动选关重新开始!");
                         log("进入队伍调整");
                         break;
@@ -6088,7 +6088,7 @@ function algo_init() {
                     //如果在开启“优先使用官方自动续战”的同时,还开启了“只对优选助战使用官方自动续战”,
                     //那么是否要优先点击自动续战按钮还得考虑这一次(每次情况都可能不一样)有没有找到符合优选条件的助战
                     //这里赋值为true或false,避免把object或undefined赋值进去
-                    var shouldUseAuto = (limit.useAuto&&(!limit.autoForPreferredOnly||lastFoundPreferredChara)) ? true : false;
+                    var shouldUseAuto = (limit.useAuto&&(!limit.autoForPreferredOnly||(limit.preferredSupportCharaNames===""||limit.preferredSupportCharaNames==null||lastFoundPreferredChara))) ? true : false;
 
                     //走到这里时肯定至少已经检测到开始按钮,即nextPageBtn
                     //因为后面检测误触弹窗和按钮比较慢,先闭着眼点一下开始或自动续战按钮


### PR DESCRIPTION
优选助战列表如果留空了，如hint所述，是“不进行优选”、关闭这个功能的意思。

然而实际上如果开启了“只对优选助战使用官方自动续战”，就实质上变成了“停用官方自动续战”，即便开启了“优先使用官方自动续战”，也仍然不会点击自动续战按钮。这个和直觉与软件界面上的描述都不符。

所以这里就修正一下。