### PR TITLE
理子脚本:尝试解决某OPPO真机大概率在点击区域后不能继续点确定的问题

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -4912,7 +4912,21 @@ function algo_init() {
                     }
                     if (regionEntry != null && OKButton == null && startButton == null) {
                         log("区域"+routeData.regionNum+"出现了,而且确定/开始按钮没有出现,重新检测状态");
-                        state = detectState();
+                        //正常情况下应该进入地图才对,貌似有时候无障碍服务抽风了,就会因为什么控件都检测不到而误检测为战斗状态
+                        let detectedState = detectState();
+                        if (detectedState != STATE_MAP && detectedState != STATE_MENU) {
+                            log("detectState()返回了既不是STATE_MAP也不是STATE_MENU的结果:["+detectedState+"]");
+                            if (menuStateAbnormalityCount++ < 5) {
+                                toastLog("等待2秒后重试...");
+                                sleep(2000);
+                            } else {
+                                toastLog("多次重试后仍然不正常,杀进程重开游戏...");
+                                killGame();
+                                state = STATE_CRASHED;
+                            }
+                        } else {
+                            state = detectedState;
+                        }
                         break;
                     }
                     break;

--- a/floatUI.js
+++ b/floatUI.js
@@ -4792,6 +4792,7 @@ function algo_init() {
 
         var battleCount = 0;
         var lastBattleCountOnKillGame = 0;
+        var menuStateAbnormalityCount = 0;
 
         while (true) {
             //检测游戏是否闪退
@@ -4923,9 +4924,11 @@ function algo_init() {
                                 toastLog("多次重试后仍然不正常,杀进程重开游戏...");
                                 killGame();
                                 state = STATE_CRASHED;
+                                menuStateAbnormalityCount = 0;
                             }
                         } else {
                             state = detectedState;
+                            menuStateAbnormalityCount = 0;
                         }
                         break;
                     }


### PR DESCRIPTION
```
2021-10-08 08:01:03.586/DEBUG: 已完成这一轮的所有战斗
2021-10-08 08:01:03.820/DEBUG: 点击断线重连按钮所在区域
2021-10-08 08:01:03.902/DEBUG: 使用无障碍服务模拟点击坐标 586,500
2021-10-08 08:01:04.056/DEBUG: 点击完成
2021-10-08 08:01:05.495/DEBUG: 点击断线重连按钮所在区域
2021-10-08 08:01:05.771/DEBUG: 使用无障碍服务模拟点击坐标 586,500
2021-10-08 08:01:05.925/DEBUG: 点击完成
2021-10-08 08:01:07.599/DEBUG: 点击断线重连按钮所在区域
2021-10-08 08:01:07.812/DEBUG: 使用无障碍服务模拟点击坐标 586,500
2021-10-08 08:01:07.970/DEBUG: 点击完成
2021-10-08 08:01:09.098/DEBUG: 已退出战斗结算界面,再等待10秒...
2021-10-08 08:01:19.761/DEBUG: 点击区域10
2021-10-08 08:01:19.899/DEBUG: 使用无障碍服务模拟点击坐标 1012,154
2021-10-08 08:01:20.058/DEBUG: 点击完成
2021-10-08 08:01:21.221/DEBUG: 区域10出现了,而且确定/开始按钮没有出现,重新检测状态
2021-10-08 08:01:21.481/DEBUG: 点击区域10
2021-10-08 08:01:21.602/DEBUG: 使用无障碍服务模拟点击坐标 1012,154
2021-10-08 08:01:21.761/DEBUG: 点击完成
2021-10-08 08:01:22.792/DEBUG: 点击确定
2021-10-08 08:01:22.944/DEBUG: 使用无障碍服务模拟点击坐标 1092,556
2021-10-08 08:01:23.103/DEBUG: 点击完成
2021-10-08 08:01:24.344/DEBUG: 点击区域10
2021-10-08 08:01:24.424/DEBUG: 使用无障碍服务模拟点击坐标 580,182
2021-10-08 08:01:24.581/DEBUG: 点击完成
2021-10-08 08:01:26.190/DEBUG: 区域10出现了,而且确定/开始按钮没有出现,重新检测状态
2021-10-08 08:01:43.823/DEBUG: 点击断线重连按钮所在区域
2021-10-08 08:01:44.478/DEBUG: 使用无障碍服务模拟点击坐标 586,500
2021-10-08 08:01:44.638/DEBUG: 点击完成
2021-10-08 08:01:44.939/DEBUG: 点击OK按钮区域
2021-10-08 08:01:51.170/DEBUG: 使用无障碍服务模拟点击坐标 760,512
2021-10-08 08:01:51.325/DEBUG: 点击完成
2021-10-08 08:01:51.627/DEBUG: 点击战斗已结束OK按钮区域
2021-10-08 08:01:54.751/DEBUG: 使用无障碍服务模拟点击坐标 760,440
2021-10-08 08:01:54.911/DEBUG: 点击完成
...
2021-10-08 16:23:29.280/DEBUG: Android API Level 27
2021-10-08 16:23:29.281/DEBUG: 屏幕分辨率 720 1520
2021-10-08 16:23:29.283/DEBUG: 
brand OPPO
device PBBM30
model PBBM30
product PBBM30
hardware qcom
```
用户反馈实际上停在点击区域后的界面，本来点击确定后就要调整队伍的。