### PR TITLE
修正刘海屏横屏下悬浮窗靠右时超出屏幕范围的问题

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -698,12 +698,6 @@ floatUI.main = function () {
     })();};
 
     //切换悬浮窗靠左/靠右,切换后X轴方向会反转。
-    //之所以需要这个函数,是因为一开始发现getDefaultDisplay().getSize()可能(概率性)返回横竖屏方向错误的数据,
-    //于是当时就导致了悬浮窗(概率性)显示异常,尤其是capture捕获点击坐标受影响最大,只能覆盖左半个屏幕。
-    //搜索研究后,找到了模仿wm size命令的方法(getInitialDisplaySize)来获取“自然转屏方向”下屏幕分辨率数据的方法,
-    //然后,据此修改了getWindowSize函数,配合getDefaultDisplay().getRotation()貌似就解决了转盘方向不对的问题。
-    //但这样又导致刘海屏下,悬浮窗靠右时,会(因为没考虑刘海扣除的X轴距离)而超出屏幕范围,
-    //于是现在就只能用这个很hack、而且会导致悬浮窗调用getX/setPosition时X轴方向反转的办法了。
     function toggleFloatyGravityLeftRight(floatyRawWindow, isRight) {
         let field = floatyRawWindow.getClass().getDeclaredField("mWindow");
         field.setAccessible(true);

--- a/floatUI.js
+++ b/floatUI.js
@@ -1034,22 +1034,12 @@ floatUI.main = function () {
                 }
 
                 //更新QB头像和5个按钮的位置
-                var x = menu.getX();
-                if (x <= 0) {
-                    //停靠屏幕左边缘
-                    menu.setPosition(0, calcMenuY());
-                    submenu.setPosition(
-                        0,
-                        parseInt(menu.getY() - (submenu.getHeight() - menu.getHeight()) / 2)
-                    );
-                } else {
-                    //停靠屏幕右边缘
-                    menu.setPosition(sz.x - menu.getWidth(), calcMenuY());
-                    submenu.setPosition(
-                        sz.x - submenu.getWidth(),
-                        parseInt(menu.getY() - (submenu.getHeight() - menu.getHeight()) / 2)
-                    );
-                }
+                //因为toggleFloatyGravityLeftRight函数的作用,无论是停靠屏幕左边缘还是右边缘,X坐标值设为0都代表停靠屏幕边缘
+                menu.setPosition(0, calcMenuY());
+                submenu.setPosition(
+                    0,
+                    parseInt(menu.getY() - (submenu.getHeight() - menu.getHeight()) / 2)
+                );
             } else {
                 try {
                     context.unregisterReceiver(receiver);


### PR DESCRIPTION
Fix #208

1. 一开始发现`getDefaultDisplay().getSize()`可能（概率性）返回横竖屏方向错误的数据（ #89 #110 等等），当时就导致了悬浮窗（概率性）显示异常，尤其是capture捕获点击坐标受影响最大，只能覆盖左半个屏幕（如果只看这一个问题，刚刚才意识到其实有很简单的解决办法 #273 ，但问题不仅限于此，比如脚本选择悬浮窗也会显示不正常，内容挤在屏幕左边、而且下面还会超出屏幕显示范围之外）。

2. 搜索研究后，找到了模仿`wm size`命令（`getInitialDisplaySize`）来获取“自然转屏方向”下屏幕分辨率数据的方法，然后，据此修改了`getWindowSize`函数，配合`getDefaultDisplay().getRotation()`貌似就解决了转盘方向不对的问题（ #164 ）。但这样又导致刘海屏下，悬浮窗靠右时，会（因为没考虑刘海扣除的X轴距离）而超出屏幕范围（ #208 ）。

3. 于是现在就只能用这个很hack、而且会导致悬浮窗调用getX/setPosition时X轴方向反转的办法了。