### PR TITLE
捕获坐标的overlay悬浮窗大小直接设为MATCH_PARENT

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -1106,8 +1106,7 @@ floatUI.main = function () {
         touch_down_pos = null;
         touch_up_pos = null;
         ui.post(() => {
-            var sz = getWindowSize();
-            overlay.setSize(sz.x, sz.y);
+            overlay.setSize(-1, -1);//android.view.ViewGroup.LayoutParams.MATCH_PARENT
             overlay.container.description_text.setText(description_text);
             overlay.container.setVisibility(View.VISIBLE);
             overlay.setTouchable(true);


### PR DESCRIPTION
先问一下 @deepin-pointer 为什么之前没有直接设为MATCH_PARENT（-1）（明明AutoJS官方文档里都有提到），是不是有什么特别的理由？