### PR TITLE
【6.0.4】避免updateUI因为无障碍抽风而崩溃

### DIFF
--- a/floatUI.js
+++ b/floatUI.js
@@ -2314,7 +2314,7 @@ function updateUI() {
         let item = {name: name, funcName: funcName, arg: arg};
         delete floatUI.settingsUIRefreshingList[name];//防止更新顺序出错
         floatUI.settingsUIRefreshingList[name] = item;//同样的操作只进行最后一次,覆盖掉前一次
-        if (auto.service != null && auto.root.packageName() === context.getPackageName()) {
+        if (auto.service != null && auto.root != null && auto.root.packageName() === context.getPackageName()) {
             floatUI.refreshUI();
         }
     });

--- a/main.js
+++ b/main.js
@@ -8,7 +8,7 @@ importClass(Packages.androidx.core.graphics.drawable.DrawableCompat)
 importClass(Packages.androidx.appcompat.content.res.AppCompatResources)
 
 var Name = "AutoBattle";
-var version = "6.0.3";
+var version = "6.0.4";
 var appName = Name + " v" + version;
 
 //注意:这个函数只会返回打包时的版本，而不是在线更新后的版本！

--- a/project.json
+++ b/project.json
@@ -5,7 +5,7 @@
         "build"
     ],
     "packageName": "top.momoe.auto",
-    "versionName": "6.0.3",
+    "versionName": "6.0.4",
     "versionInfo": "",
     "versionCode": 1,
     "icon":"./images/icon.png",


### PR DESCRIPTION
```
2021-10-17 09:40:15.140/DEBUG: 重新登录...
2021-10-17 09:40:18.571/DEBUG: 点击OK按钮区域...
2021-10-17 09:40:18.578/DEBUG: 使用Shizuku模拟点击: [960,769]
2021-10-17 09:40:20.116/DEBUG: 使用Shizuku模拟点击: [960,769] 完成
2021-10-17 09:40:20.117/DEBUG: 点击OK按钮区域完成,等待1秒...
2021-10-17 09:40:21.118/DEBUG: 点击战斗已结束OK按钮区域...
2021-10-17 09:40:21.163/DEBUG: 使用Shizuku模拟点击: [960,660]
2021-10-17 09:40:22.379/DEBUG: 使用Shizuku模拟点击: [960,660] 完成
2021-10-17 09:40:22.386/DEBUG: 点击战斗已结束OK按钮区域完成,等待1秒...
2021-10-17 09:40:28.614/DEBUG: 游戏已经闪退
2021-10-17 09:40:28.622/DEBUG: 检测到游戏再次闪退,无法继续登录
2021-10-17 09:40:28.622/DEBUG: 已恢复上次的选关动作录制数据
2021-10-17 09:40:38.487/DEBUG: 使用Shizuku执行shell命令: [runbg() { "/data/local/tmp/auto_magireco_fatal_killer.sh" > /dev/null & }; runbgbg() { runbg & }; runbgbg & exit;
] 完成
2021-10-17 09:40:38.759/DEBUG: 无障碍服务似乎工作不正常
最好重新开启一下无障碍服务
auto.root == null
2021-10-17 09:41:07.199/ERROR: Thread[main,5]: TypeError: Cannot call method "packageName" of null
    at file:///android_asset/modules/__ui__.js:151:0
    at updateUI (file:/data/data/top.momoe.auto/files/project/floatUI.js:2307:0)
    at file:/data/data/top.momoe.auto/files/project/floatUI.js:315:0
    at file:/data/data/top.momoe.auto/files/project/floatUI.js:81:0
    at file:/data/data/top.momoe.auto/files/project/floatUI.js:401:0
```