### PR TITLE
继续修正在线更新

### DIFF
--- a/main.js
+++ b/main.js
@@ -1303,8 +1303,8 @@ var fixFiles = sync(function (corruptOrMissingFileList, specifiedVersionName) {
     toastLog("开始下载文件数据以供修复...");
 
     corruptOrMissingFileList.forEach((item) => {
-        log("下载文件 ["+item.src+"]");
-        try {
+        if (item.dataBytes == null) try {
+            log("下载文件 ["+item.src+"]");
             let resp = http.get(getDownloadURLBase(specifiedVersionName)+"/"+(item.origFileName != null ? item.origFileName : item.src));
             if (resp.statusCode == 200) {
                 let downloadedBytes = resp.body.bytes();

--- a/main.js
+++ b/main.js
@@ -1135,12 +1135,18 @@ var toUpdate = sync(function () {
                 let essentialFileList = ["update/updateList.json", "main.js", "floatUI.js"];
                 let responses = [];
                 essentialFileList.forEach((item) => {
+                    let resp = null;
+                    try {
+                        resp = http.get(getDownloadURLBase(latestVersionName)+"/"+item);
+                    } catch (e) {
+                        resp = null;
+                    }
                     responses.push({
                         fileName: item,
-                        httpResponse: http.get(getDownloadURLBase(latestVersionName)+"/"+item),
+                        httpResponse: resp,
                     });
                 });
-                if (responses.find((item) => item.httpResponse.statusCode != 200) == null) {
+                if (responses.find((item) => item.httpResponse != null && item.httpResponse.statusCode != 200) == null) {
                     setVersionMsgToastLog("更新已下载，写入文件并重启...", "#666666", true);
                     responses.forEach((item) => {
                         let writeToPath = files.join(files.cwd(), item.fileName);
@@ -1149,14 +1155,14 @@ var toUpdate = sync(function () {
                     });
                     restartApp();
                 } else {
-                    toast("脚本获取失败！这可能是您的网络原因造成的，建议您检查网络后再重新运行软件吧\nHTTP状态码:" + main_script.statusMessage, "," + float_script.statusMessage);
+                    toast("有文件下载失败，请稍后重试");
                 }
             } else {
                 toastLog("无需更新");
             }
         }
     } catch (error) {
-        toastLog("请求超时，可再一次尝试")
+        toastLog("更新过程出错");
     } finally {
         ui.run(function() {ui.swipe.setRefreshing(false);});
     }

--- a/main.js
+++ b/main.js
@@ -1235,12 +1235,12 @@ function checkFile(fileName, fileHash) {
 }
 
 function findCorruptOrMissingFile() {
-    //从6.1.1开始修正在线更新认不清版本的bug
+    //从6.1.2开始修正在线更新认不清版本的bug
     var specifiedVersionName = version;
-    if (parseInt(version.split(".").join("")) < parseInt("6.1.1".split(".").join(""))) {
-        specifiedVersionName = "6.1.1";
-        log("版本低于6.1.1，先更新文件数据列表到6.1.1");
-        if (downloadUpdateListJSON("6.1.1") == null) {
+    if (parseInt(version.split(".").join("")) < parseInt("6.1.2".split(".").join(""))) {
+        specifiedVersionName = "6.1.2";
+        log("版本低于6.1.2，先更新文件数据列表到6.1.2");
+        if (downloadUpdateListJSON(specifiedVersionName) == null) {
             //如果下载或写入不成功
             ui.post(function () {dialogs.alert("警告", "下载文件数据列表失败，无法检查文件数据，不能确保文件数据无误");});
             return false;

--- a/main.js
+++ b/main.js
@@ -36,11 +36,11 @@ function readUpdateList() {
             log("已读取文件数据列表");
             return result;
         } else {
-            toastLog("文件数据列表文件不存在");
+            log("文件数据列表文件不存在");
         }
     } catch (e) {
         log(e);
-        toastLog("读取文件数据列表时出错");
+        log("读取文件数据列表时出错");
     }
 }
 
@@ -1045,6 +1045,10 @@ function setVersionMsg(textMsg, color, isVisible) {
         ui.versionMsg_vertical.setVisibility(isVisible);
     })
 }
+function setVersionMsgLog(textMsg, color, isVisible) {
+    log(textMsg);
+    setVersionMsg(textMsg, color, isVisible);
+}
 function setVersionMsgToastLog(textMsg, color, isVisible) {
     toastLog(textMsg);
     setVersionMsg(textMsg, color, isVisible);
@@ -1076,9 +1080,9 @@ var refreshUpdateStatus = sync(function () {
                 log("从JSDelivr获取最新版本号"+latestVersionName);
             }
             if (parseInt(latestVersionName.split(".").join("")) <= parseInt(version.split(".").join(""))) {
-                setVersionMsgToastLog("当前无需更新", "#666666", false);
+                setVersionMsgLog("当前无需更新", "#666666", false);
             } else {
-                setVersionMsgToastLog("最新版本为" + latestVersionName + ",下拉进行更新", colors.RED, true);
+                setVersionMsgLog("最新版本为" + latestVersionName + ",下拉进行更新", colors.RED, true);
             }
         }
     } catch (e) {
@@ -1147,7 +1151,7 @@ var toUpdate = sync(function () {
                     });
                 });
                 if (responses.find((item) => item.httpResponse != null && item.httpResponse.statusCode != 200) == null) {
-                    setVersionMsgToastLog("更新已下载，写入文件并重启...", "#666666", true);
+                    setVersionMsgLog("更新已下载，写入文件并重启...", "#666666", true);
                     responses.forEach((item) => {
                         let writeToPath = files.join(files.cwd(), item.fileName);
                         let fileBytes = item.httpResponse.body.bytes();
@@ -1172,10 +1176,10 @@ var toUpdate = sync(function () {
 function downloadUpdateListJSON(specifiedVersionName) {
     try {
         let updateListURL = getDownloadURLBase(specifiedVersionName)+"/update/updateList.json";
-        toastLog("正在下载文件数据列表 ["+updateListURL+"]");
+        log("正在下载文件数据列表 ["+updateListURL+"]");
         let resp = http.get(updateListURL);
         if (resp.statusCode == 200) {
-            toastLog("已下载文件数据列表");
+            log("已下载文件数据列表");
 
             let result = resp.body.string();
 
@@ -1290,7 +1294,7 @@ function findCorruptOrMissingFile() {
         corruptOrMissingFileList.push(item);
     });
 
-    (corruptOrMissingFileList.length == 0 ? log : setVersionMsgToastLog)("发现 "+corruptOrMissingFileList.length+" 个文件丢失或损坏");
+    (corruptOrMissingFileList.length == 0 ? log : setVersionMsgLog)("发现 "+corruptOrMissingFileList.length+" 个文件丢失或损坏");
 
     return {
         versionName: updateListObj.versionName,
@@ -1313,7 +1317,7 @@ var fixFiles = sync(function (corruptOrMissingFileList, specifiedVersionName) {
         return false;
     }
 
-    setVersionMsgToastLog("开始下载文件数据以供修复...", "#666666");
+    setVersionMsgLog("开始下载文件数据以供修复...", "#666666");
 
     let downloadedCount = corruptOrMissingFileList.filter((item) => item.dataBytes != null).length;
     corruptOrMissingFileList.forEach((item) => {
@@ -1379,7 +1383,7 @@ var fixFiles = sync(function (corruptOrMissingFileList, specifiedVersionName) {
         return false;
     }
 
-    setVersionMsgToastLog("文件数据更新完成\n即将重启app", "#666666");
+    setVersionMsgLog("文件数据更新完成\n即将重启app", "#666666");
 
     restartApp();
 

--- a/main.js
+++ b/main.js
@@ -1238,6 +1238,11 @@ function findCorruptOrMissingFile() {
     let updateListObj = readUpdateList();
 
     if (updateListObj == null) {
+        downloadUpdateListJSON(specifiedVersionName);
+        updateListObj = readUpdateList();
+    }
+
+    if (updateListObj == null) {
         toastLog("无法读取或下载文件数据列表");
         return false;
     }

--- a/main.js
+++ b/main.js
@@ -1372,20 +1372,23 @@ var checkAgainstUpdateListAndFix = sync(function (showResult) {
     let specifiedVersionName = ret.versionName;
     if (Array.isArray(corruptOrMissingFileList)) {
         if (corruptOrMissingFileList.length > 0) {
-            ui.post(function () {
+            function promptRepair(textMsg) {ui.post(function () {
                 dialogs.confirm(
                     "发现文件缺失或损坏",
-                    "检查发现有"+corruptOrMissingFileList.length+"个文件缺失或损坏，要尝试重新下载来修复么？"
+                    textMsg
                 ).then((value) => {
                     if (value) {
                         threads.start(function () {
                             if (!fixFiles(corruptOrMissingFileList, specifiedVersionName)) {
-                                toastLog("检查并修复文件时出错，请稍后重试");
+                                promptRepair("下载或写入文件失败。要重试么？\n"
+                                +"一共有"+corruptOrMissingFileList.length+"个文件需要修复，\n"
+                                +"其中有"+corruptOrMissingFileList.filter((item) => item.dataBytes == null).length+"个文件需要重新下载。");
                             }
                         });
                     }
                 });
-            });
+            });}
+            promptRepair("检查发现有"+corruptOrMissingFileList.length+"个文件缺失或损坏，要尝试重新下载来修复么？");
         } else if (version !== specifiedVersionName) {
             //一般不会走到这里。所有文件验证通过时，用root权限手动删掉updateList.json后重启才会走到这里
             //这个时候脚本显示的版本仍然是老的，需要重启一次才能显示正确的版本

--- a/main.js
+++ b/main.js
@@ -14,6 +14,17 @@ importClass(Packages.androidx.core.graphics.drawable.DrawableCompat)
 importClass(Packages.androidx.appcompat.content.res.AppCompatResources)
 
 
+// 捕获异常时打log记录详细的调用栈
+// 貌似（在处理http.get下载失败时？）会导致崩溃，注释掉
+//function logException(e) {
+//    try { throw e; } catch (caught) {
+//        Error.captureStackTrace(caught, logException);
+//        //log(e, caught.stack); //输出挤在一行里了，不好看
+//        log(e);
+//        log(caught.stack);
+//    }
+//}
+
 const updateListPath = files.join(files.join(files.cwd(), "update"), "updateList.json");
 
 function readUpdateList() {
@@ -28,7 +39,7 @@ function readUpdateList() {
             toastLog("文件数据列表文件不存在");
         }
     } catch (e) {
-        logException(e);
+        log(e);
         toastLog("读取文件数据列表时出错");
     }
 }
@@ -61,16 +72,6 @@ function getCurrentVersion() {
 const Name = "AutoBattle";
 const version = getCurrentVersion();
 const appName = Name + " v" + version;
-
-// 捕获异常时打log记录详细的调用栈
-function logException(e) {
-    try { throw e; } catch (caught) {
-        Error.captureStackTrace(caught, logException);
-        //log(e, caught.stack); //输出挤在一行里了，不好看
-        log(e);
-        log(caught.stack);
-    }
-}
 
 var floatUI = require('floatUI.js');
 
@@ -767,7 +768,7 @@ if (!$floaty.checkPermission()) {
         });
     } catch (e) {
         failed = true;
-        logException(e);
+        log(e);
     }
     if (failed) {
         failed = false;
@@ -776,7 +777,7 @@ if (!$floaty.checkPermission()) {
             $floaty.requestPermission();
         } catch (e) {
             failed = true;
-            logException(e);
+            log(e);
         }
     }
     if (failed) {
@@ -1192,7 +1193,7 @@ function downloadUpdateListJSON(specifiedVersionName) {
             toastLog("下载文件数据列表失败\n"+resp.statusCode+" "+resp.statusMessage);
         }
     } catch (e) {
-        logException(e);
+        log(e);
         toastLog("下载文件数据列表失败");
     }
 }
@@ -1208,7 +1209,7 @@ function checkFile(fileName, fileHash) {
     try {
         fileBytes = files.readBytes(filePath);
     } catch (e) {
-        logException(e);
+        log(e);
         log("读取文件时出错 ["+fileName+"]");
         return false;
     }
@@ -1319,7 +1320,7 @@ var fixFiles = sync(function (corruptOrMissingFileList, specifiedVersionName) {
                 log("下载文件 ["+item.src+"] 失败\n"+resp.statusCode+" "+resp.statusMessage);
             }
         } catch (e) {
-            logException(e);
+            log(e);
             log("下载文件 ["+item.src+"] 出错");
         }
     });
@@ -1348,7 +1349,7 @@ var fixFiles = sync(function (corruptOrMissingFileList, specifiedVersionName) {
                 item.isWritten = false;
             }
         } catch (e) {
-            logException(e);
+            log(e);
             log("写入文件时出错 ["+item.src+"]");
             item.isWritten = false;
         }

--- a/main.js
+++ b/main.js
@@ -71,7 +71,7 @@ function getCurrentVersion() {
 
 const Name = "AutoBattle";
 const version = getCurrentVersion();
-const appName = Name + " v" + version;
+const appName = getUpdatedVersion() == null ? Name : Name + " v" + version;
 
 var floatUI = require('floatUI.js');
 


### PR DESCRIPTION
主要修正/改进：
1. 如果修复文件过程中有文件下载失败，则对话框提示重试
2. 没开网的时候，logException貌似在处理http.get抛出无法解析DNS的异常，然后虽然app没崩但单开的线程崩了，通过换回log来避免这个问题
3. 下载时提示进度
4. toUpdate里有个报错语句中main_js没改干净，改掉
5. 避免看似“反向更新”的问题：之前没想太多，如果没有updateList.json（版本号就是从这里读取的）就让他显示打包时的版本号（因为我觉得version这个变量总得填上一个值），这样看上去就好像“反向更新”了，实际上（基本上）只是更新过程还没完成，还需要“下载并修复文件”才算完成。现在改成不确定版本号时就不显示版本号，减少误解。